### PR TITLE
change start_cluster arg from num_workers to add_workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ pip install 'git+ssh://git@github.com/facebookresearch/matrix.git#egg=matrix[vll
 
 - Launch ray cluster
 ```
-matrix start_cluster --num_workers 1 --slurm "{'account': $SLURM_ACCOUNT, 'qos': $SLURM_QOS}"
+matrix start_cluster --add_workers 1 --slurm "{'account': $SLURM_ACCOUNT, 'qos': $SLURM_QOS}"
 ```
 
 - Deploy Model
@@ -69,7 +69,7 @@ matrix start_cluster --enable_grafana
 
 - Add More Workers
 ```
-matrix start_cluster --num_workers 4 --slurm "{'account': $SLURM_ACCOUNT, 'qos': $SLURM_QOS}"
+matrix start_cluster --add_workers 4 --slurm "{'account': $SLURM_ACCOUNT, 'qos': $SLURM_QOS}"
 ```
 
 - Add/Remove Applications
@@ -112,12 +112,14 @@ matrix deploy_applications --applications "[{'app_type': 'gemini', 'name': "gemi
 ### Deepseek R1
 ```
 // install sglang
-pip install 'git+ssh://git@github.com/fairinternal/matrix.git#egg=matrix[sglang_043]'
+pip install 'git+ssh://git@github.com/facebookresearch/matrix.git#egg=matrix[sglang_043]'
 
 matrix deploy_applications --applications "[{'model_name': 'deepseek-ai/DeepSeek-R1', 'min_replica': 2, 'app_type': sglang_llm}]"
 ```
 ### Llama 4
 ```
+pip install 'git+ssh://git@github.com/facebookresearch/matrix.git#egg=matrix[vllm_083]'
+
 matrix deploy_applications --applications "[{'model_name': 'meta-llama/Llama-4-Scout-17B-16E-Instruct'}]"
 
 matrix deploy_applications --applications "[{'model_name': 'meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8'}]"
@@ -135,19 +137,24 @@ matrix llm_inference --app_name maverick-fp8 --input_jsonls test.jsonl --output_
 
 #### Input Format
 There are two format for the jsonl input files:
-  - Message foramt:
+  - Message foramt with arg --messages_key request.messages
 ```json
 {
     "request": {"messages": [{"role": "system","content": "You are ..."},{"role": "user","content": "Solve the following..."}]}
 }
 ```
-  - Instruct format:
+  - Instruct format with arg --text_key text
 ```json
 {
     "text": "<|start_header_id|>system<|end_header_id|>You are ... <|eot_id|><|start_header_id|>user<|end_header_id|>Solve the following ...<|eot_id|><|start_header_id|>assistant<|end_header_id|>"
 }
 ```
-
+  - Raw tax with arg --text_key text
+```json
+{
+    "text": "Solve the following ..."
+}
+```
 ### Inference API
 ```
 from matrix import Cli
@@ -194,7 +201,7 @@ If you use matrix in your research and wish to refer to it, please use the
 following BibTeX entry.
 
 ```
-@software{dongwang2025matrix,
+@software{wang2025matrix,
   author = {Dong Wang and Yang Li and Ansong Ni and Youssef Emad and Xinjie Lei and Ruta Desai and Asli Celikyilmaz and Daniel Li},
   title = {Matrix},
   url = {http://github.com/facebookresearch/matrix},

--- a/matrix/app_server/llm/openai.proto
+++ b/matrix/app_server/llm/openai.proto
@@ -1,3 +1,9 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+
 syntax = "proto3";
 
 package matrix.app_server.llm;

--- a/matrix/cli.py
+++ b/matrix/cli.py
@@ -76,7 +76,7 @@ class Cli:
 
     def start_cluster(
         self,
-        num_workers: int = 0,
+        add_workers: int = 0,
         slurm: tp.Dict[str, tp.Union[str, int]] | None = None,
         local: tp.Dict[str, tp.Union[str, int]] | None = None,
         enable_grafana: bool = False,
@@ -93,7 +93,7 @@ class Cli:
         Can add additional workers if the cluster already exists.
         
         Args:
-            num_workers (int): Number of worker nodes to add in the cluster.
+            add_workers (int): Number of worker nodes to add in the cluster.
             slurm (dict, optional): resources for slurm cluster.
             local (dict, optional): resources for local cluster.
             enable_grafana (bool, optional): If True, enable prometheus and grafana dashboard.
@@ -101,7 +101,7 @@ class Cli:
         Returns:
             None
         """
-        self.cluster.start(num_workers, slurm, local, enable_grafana=enable_grafana)
+        self.cluster.start(add_workers, slurm, local, enable_grafana=enable_grafana)
 
     def stop_cluster(self):
         """

--- a/matrix/cluster/ray_cluster.py
+++ b/matrix/cluster/ray_cluster.py
@@ -155,7 +155,7 @@ class RayCluster:
 
     def start(
         self,
-        num_workers: int,
+        add_workers: int,
         slurm: tp.Dict[str, tp.Union[str, int]] | None,
         local: tp.Dict[str, tp.Union[str, int]] | None,
         enable_grafana: bool = False,
@@ -167,7 +167,7 @@ class RayCluster:
         or add worker nodes to an existing cluster.
 
         Args:
-            num_workers (int): The number of worker nodes to start.
+            add_workers (int): The number of worker nodes to start.
             requirements (dict): Slurm resource requirements for worker nodes.
                                  e.g., {'qos': '...', 'partition': '...', 'gpus-per-node': 8}.
             head_requirements (dict): optional to specify head requirements when launching head.
@@ -191,7 +191,7 @@ class RayCluster:
                 cluster=executor,
             )
             default_params = {"cpus_per_task": 10, "timeout_min": 10080}
-            if num_workers == 0:
+            if add_workers == 0:
                 head_params = requirements
             else:
                 head_params = {
@@ -250,7 +250,7 @@ class RayCluster:
             self.start_grafana(force=True)
 
         # start the workers
-        if num_workers > 0:
+        if add_workers > 0:
             s_executor = submitit.AutoExecutor(
                 folder=str(self.log_dir), cluster=executor
             )
@@ -278,7 +278,7 @@ class RayCluster:
             with (
                 s_executor.batch()
             ):  # TODO set slurm array max parallelism here, because we really want all jobs to be scheduled at the same time
-                for i in range(num_workers):
+                for i in range(add_workers):
                     jobs.append(
                         s_executor.submit(
                             RayWorkerJob(

--- a/tests/integration/app_server/test_deploy_hello.py
+++ b/tests/integration/app_server/test_deploy_hello.py
@@ -21,7 +21,7 @@ def matrix_cluster() -> Generator[Any, Any, Any]:
     with tempfile.TemporaryDirectory() as temp_dir:
         cli = Cli(cluster_id=str(uuid.uuid4()), matrix_dir=temp_dir)
         cli.start_cluster(
-            num_workers=1,
+            add_workers=1,
             slurm=None,
             local={"gpus_per_node": 0, "cpus_per_task": 2},
             enable_grafana=False,


### PR DESCRIPTION
## Why ?
The start_cluster command is confusing. The num_workers arg is used to add workers instead of specify the total workers.

Other small changes to README.md

## How ?

Change to --add_workers

## Test plan

matrix start_cluster --add_workers 3 --slurm "{'account': $SLURM_ACCOUNT, 'qos': $SLURM_QOS}"
