### PR TITLE
enable lora modules

### DIFF
--- a/matrix/app_server/llm/ray_serve_vllm.py
+++ b/matrix/app_server/llm/ray_serve_vllm.py
@@ -380,6 +380,13 @@ class GrpcDeployment(BaseDeployment):
         )
         logger.debug(f"Request: {chat}")
         try:
+            if (
+                self.openai_serving_chat.models.static_lora_modules
+                and len(self.openai_serving_chat.models.lora_requests) == 0
+            ):
+                # only need for lora modules, at vllm >= v0.7.0
+                # due to https://github.com/vllm-project/vllm/commit/ac2f3f7fee93cf9cd97c0078e362feab7b6c8299
+                await self.openai_serving_chat.models.init_static_loras()
             generator = await self.openai_serving_chat.create_chat_completion(chat)
             if isinstance(generator, ErrorResponse):
                 status_code = self.http_to_grpc_status(generator.code)
@@ -417,6 +424,13 @@ class GrpcDeployment(BaseDeployment):
         )
         logger.debug(f"Request: {completion_request}")
         try:
+            if (
+                self.openai_serving_chat.models.static_lora_modules
+                and len(self.openai_serving_chat.models.lora_requests) == 0
+            ):
+                # only need for lora modules, at vllm >= v0.7.0
+                # due to https://github.com/vllm-project/vllm/commit/ac2f3f7fee93cf9cd97c0078e362feab7b6c8299
+                await self.openai_serving_chat.models.init_static_loras()
             generator = await self.openai_serving_completion.create_completion(
                 completion_request,
                 Request(  # this Request is purely dummy, it is changed to optional in vllm's recent pull https://github.com/vllm-project/vllm/pull/12503


### PR DESCRIPTION
## Why ?

add a lora model example.
In this PR, we explicitly call init_static_loras() to load lora_request, this is due a change in vllm @ 0.7.0 https://github.com/vllm-project/vllm/commit/ac2f3f7fee93cf9cd97c0078e362feab7b6c8299. Not sure why they made such change..

## How ?

when deploy, need to specify lora-modules
e.g. {'lora-modules': 'sql-lora=/checkpoint/comem/huggingface_models/mistral_based_claim_extractor'}

and then in make_request, model="sql-lora"
