### PR TITLE
minor changes on command

### DIFF
--- a/matrix/__main__.py
+++ b/matrix/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":
+    main()

--- a/matrix/cli.py
+++ b/matrix/cli.py
@@ -80,6 +80,7 @@ class Cli:
         slurm: tp.Dict[str, tp.Union[str, int]] | None = None,
         local: tp.Dict[str, tp.Union[str, int]] | None = None,
         enable_grafana: bool = False,
+        force_new_head: bool = False,
     ):
         """
         Starts the Ray cluster with additional keyword arguments. Only do this for new clusters.
@@ -97,11 +98,18 @@ class Cli:
             slurm (dict, optional): resources for slurm cluster.
             local (dict, optional): resources for local cluster.
             enable_grafana (bool, optional): If True, enable prometheus and grafana dashboard.
-        
+            force_new_head (bool): force to remove head.json if haven't run 'matrix stop_cluster'.
+            
         Returns:
             None
         """
-        self.cluster.start(add_workers, slurm, local, enable_grafana=enable_grafana)
+        self.cluster.start(
+            add_workers,
+            slurm,
+            local,
+            enable_grafana=enable_grafana,
+            force_new_head=force_new_head,
+        )
 
     def stop_cluster(self):
         """
@@ -370,7 +378,3 @@ class Cli:
 
 def main():
     fire.Fire(Cli)
-
-
-if __name__ == "__main__":
-    main()

--- a/matrix/cluster/ray_dashboard_job.py
+++ b/matrix/cluster/ray_dashboard_job.py
@@ -15,8 +15,6 @@ from typing import List
 
 import ray
 
-from matrix.common.cluster_info import ClusterInfo
-
 # Configure logging
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
@@ -38,14 +36,14 @@ class RayDashboardJob:
     properly when the actor is killed.
     """
 
-    def __init__(self, cluster_info: ClusterInfo):
+    def __init__(self, temp_dir: str, prometheus_port: int, grafana_port: int):
         """
         Initialize the RayDashboardJob actor.
         """
         self.head_env = os.environ.copy()
-        self.temp_dir = cluster_info.temp_dir
-        self.prometheus_port = cluster_info.prometheus_port
-        self.grafana_port = cluster_info.grafana_port
+        self.temp_dir = temp_dir
+        self.prometheus_port = prometheus_port
+        self.grafana_port = grafana_port
         self.processes: List[subprocess.Popen[str]] = []
         self.monitor_thread: threading.Thread | None = None
         self.should_run = True


### PR DESCRIPTION
## Why ?
1. add `force_new_head` tag in start_cluster(). If there is an old head.json, it will remove it and create a new one. Best practice is still kill the cluster by `matrix stop_cluster`, rather than manually scancel slurm jobs.
2. add __main__.py to run matrix from source repo. This will not affect installed matrix command
3. remove ClusterInfo dependency from ray_dashboard_job.py

## Test plan

in source repo, `python -m matrix start_cluster --enable_grafana --force_new_head`