### PR TITLE
add bedrock claude model

### DIFF
--- a/matrix/app_server/app_api.py
+++ b/matrix/app_server/app_api.py
@@ -372,7 +372,15 @@ class AppApi:
                 return host
 
         app_type = metadata["app_type"]
-        if app_type in ["llm", "sglang_llm"]:
+        if app_type in [
+            "llm",
+            "sglang_llm",
+            "openai",
+            "metagen",
+            "sagemaker",
+            "gemini",
+            "bedrock",
+        ]:
             from matrix.client.query_llm import main as query_llm
 
             return asyncio.run(

--- a/matrix/app_server/deploy_utils.py
+++ b/matrix/app_server/deploy_utils.py
@@ -228,13 +228,15 @@ def get_app_type(app):
     assert "deployments" in app
     deployment = app["deployments"][0]["name"]
     deploy_type = {
-        "HelloDeployment": "hello",
         "CodeExecutionApp": "code",
         "GrpcDeployment": "llm",
         "VLLMDeployment": "llm",
         "SglangDeployment": "sglang_llm",
     }
-    return deploy_type.get(deployment, "unknown")
+    app_type = deploy_type.get(deployment)
+    if app_type is None and deployment.endswith("Deployment"):
+        app_type = deployment.removesuffix("Deployment").lower()
+    return app_type or "unknown"
 
 
 def write_yaml_file(yaml_file, sglang_yaml_file, update_apps):

--- a/matrix/app_server/deploy_utils.py
+++ b/matrix/app_server/deploy_utils.py
@@ -153,6 +153,26 @@ other_app_template = """
       target_ongoing_requests: 64
       min_replicas: {{ app.min_replica }}
       max_replicas: {{ app.max_replica }}
+{% elif app.app_type == 'bedrock' %}
+- name: {{ app.name }}
+  route_prefix: /{{ app.name }}
+  import_path: matrix.app_server.llm.bedrock_proxy:build_app
+  runtime_env:
+    env_vars:
+        AWS_ACCESS_KEY_ID: {{ env.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: {{ env.AWS_SECRET_ACCESS_KEY }}
+        AWS_SESSION_TOKEN: {{ env.AWS_SESSION_TOKEN }}
+  args:
+    aws_region: {{ app.aws_region }}
+    model: {{ app.model_name }}
+    anthropic_version: {{ app.anthropic_version }}
+  deployments:
+  - name: BedrockDeployment
+    max_ongoing_requests: {{ app.max_ongoing_requests }}
+    autoscaling_config:
+      target_ongoing_requests: 64
+      min_replicas: {{ app.min_replica }}
+      max_replicas: {{ app.max_replica }}
   {% elif app.app_type == 'code' %}
 - name: {{ app.name }}
   route_prefix: /{{ app.name }}
@@ -307,6 +327,7 @@ def get_yaml_for_deployment(
                 "metagen",
                 "sagemaker",
                 "gemini",
+                "bedrock",
             ], f"unknown app_type {app_type}"
             app["app_type"] = app_type
             if "min_replica" not in app:
@@ -376,6 +397,17 @@ def get_yaml_for_deployment(
                 assert "api_key" in app, "add api_key to gemini app"
                 assert "model_name" in app, "add model_name to gemini app"
                 yaml_str += Template(other_app_template).render(app=app)
+            elif app_type == "bedrock":
+                default_params = {
+                    "name": "bedrock",
+                    "max_ongoing_requests": 10,
+                    "aws_region": "us-west-2",
+                    "anthropic_version": "bedrock-2023-05-31",
+                }
+                app.update({k: v for k, v in default_params.items() if k not in app})
+                assert "model_name" in app, "add model_name to bedrock app"
+                env = {k: v for k, v in os.environ.items() if k.startswith("AWS_")}
+                yaml_str += Template(other_app_template).render(app=app, env=os.environ)
             else:
                 assert "name" in app, "add name to app"
                 yaml_str += Template(other_app_template).render(app=app)

--- a/matrix/app_server/llm/bedrock_proxy.py
+++ b/matrix/app_server/llm/bedrock_proxy.py
@@ -70,7 +70,7 @@ class BedrockDeployment:
             "max_tokens": completion_request.get("max_tokens", 1024),
         }
         messages = completion_request.get("messages")
-        if messages[0]["role"] == "system":
+        if messages is not None and messages[0]["role"] == "system":
             request_params["system"] = messages[0]["content"]
             request_params["messages"].pop(0)
 
@@ -81,8 +81,10 @@ class BedrockDeployment:
             body=json.dumps(request_params),
             modelId=self.model_name,
         )
-        response: Dict[str, Any] = await loop.run_in_executor(None, invoke_func)
-
+        try:
+            response: Dict[str, Any] = await loop.run_in_executor(None, invoke_func)
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=str(e))
         completion_response = None
         if "body" in response:
             completion_response = json.loads(response["body"].read())

--- a/matrix/app_server/llm/bedrock_proxy.py
+++ b/matrix/app_server/llm/bedrock_proxy.py
@@ -1,0 +1,139 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import asyncio
+import concurrent
+import functools
+import json
+import logging
+import os
+from argparse import ArgumentParser
+from typing import Any, Callable, Dict
+
+import boto3
+from fastapi import FastAPI, HTTPException
+from ray import serve
+from starlette.requests import Request
+from vllm.entrypoints.openai.protocol import ChatCompletionRequest
+
+logger = logging.getLogger("ray.serve")
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("openai._base_client").setLevel(logging.WARNING)
+
+app = FastAPI()
+
+
+@serve.deployment(
+    autoscaling_config={
+        "min_replicas": 1,
+        "max_replicas": 1,
+        "target_ongoing_requests": 64,
+    },
+    max_ongoing_requests=64,  # make this large so that multi-turn can route to the same replica
+)
+@serve.ingress(app)
+class BedrockDeployment:
+    def __init__(
+        self,
+        aws_region: str,
+        model_name: str,
+        anthropic_version: str,
+    ):
+        self.aws_region = aws_region
+        self.model_name = model_name
+        self.anthropic_version = anthropic_version
+
+    def _get_client(self) -> boto3.client:
+        return boto3.client(
+            "bedrock-runtime",
+            region_name=self.aws_region,
+        )
+
+    @app.post("/v1/chat/completions")
+    async def create_chat_completion(
+        self, request: ChatCompletionRequest, raw_request: Request
+    ):
+        """OpenAI-compatible HTTP endpoint.
+
+        API reference:
+            - https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html
+        """
+        completion_request = request.model_dump(exclude_unset=True)
+        request_params = {
+            "anthropic_version": self.anthropic_version,
+            "messages": completion_request.get("messages"),
+            "temperature": completion_request.get("temperature", 0.6),
+            "top_p": completion_request.get("top_p", 0.9),
+            "max_tokens": completion_request.get("max_tokens", 1024),
+        }
+        messages = completion_request.get("messages")
+        if messages[0]["role"] == "system":
+            request_params["system"] = messages[0]["content"]
+            request_params["messages"].pop(0)
+
+        client: boto3.client = self._get_client()
+        loop = asyncio.get_running_loop()
+        invoke_func: Callable[[], Dict[str, Any]] = functools.partial(
+            client.invoke_model,
+            body=json.dumps(request_params),
+            modelId=self.model_name,
+        )
+        response: Dict[str, Any] = await loop.run_in_executor(None, invoke_func)
+
+        completion_response = None
+        if "body" in response:
+            completion_response = json.loads(response["body"].read())
+        if not completion_response:
+            raise HTTPException(status_code=400, detail=response)
+        if "content" in completion_response:
+            completion_response["choices"] = [
+                {
+                    "finish_reason": completion_response.get("stop_reason"),
+                    "index": 0,
+                    "message": {
+                        "content": completion_response["content"][0].get("text"),
+                        "role": completion_response.get("role", "assistant"),
+                    },
+                }
+            ]
+        if "usage" in completion_response:
+            usage = completion_response["usage"]
+            usage["completion_tokens"] = usage.get("output_tokens", 0)
+            usage["prompt_tokens"] = usage.get("input_tokens", 0)
+        return completion_response
+
+
+def build_app(cli_args: Dict[str, str]) -> serve.Application:
+    """Builds the Serve app based on CLI arguments."""  # noqa: E501
+    pg_resources = []
+    pg_resources.append({"CPU": 2})  # for the deployment replica
+
+    argparse = ArgumentParser()
+    argparse.add_argument("--aws_region", type=str, default="us-west-2")
+    argparse.add_argument("--model_name", type=str, required=True)
+    argparse.add_argument("--anthropic_version", type=str, default="bedrock-2023-05-31")
+
+    arg_strings = []
+    for key, value in cli_args.items():
+        if value is None:
+            arg_strings.extend([f"--{key}"])
+        else:
+            arg_strings.extend([f"--{key}", str(value)])
+    logger.info(arg_strings)
+
+    args = argparse.parse_args(args=arg_strings)
+
+    logger.log(logging.INFO, f"args: {args}")
+    assert "claude" in args.model_name.lower(), "Only Claude model is supported"
+
+    return BedrockDeployment.options(  # type: ignore[attr-defined]
+        placement_group_bundles=pg_resources,
+        placement_group_strategy="STRICT_PACK",
+    ).bind(
+        args.aws_region,
+        args.model_name,
+        args.anthropic_version,
+    )

--- a/matrix/job/job_manager.py
+++ b/matrix/job/job_manager.py
@@ -542,7 +542,7 @@ class JobManager:
                 task_id,
                 {
                     "success": False,
-                    "error": f"Task timed out after exceeding {task_info['timeout']} seconds",
+                    "error": f"Task timed out after exceeding {timeout} seconds",
                 },
             )
 


### PR DESCRIPTION
## Why ?

Calling claude models in AWS bedrock

## How ?

* pass AWS_ env variables to backend
* call bedrock with boto3 and parse the output into openai response format

## Test plan

Set the the AWS_ env variable
```
matrix deploy_applications --applications "[{'app_type': 'bedrock', 'model_name': 'us.anthropic.claude-3-7-sonnet-20250219-v1:0', 'name': 'claude'}]"

matrix check_health --app-name claude --use_curl False
```