### PR TITLE
minor fixes

### DIFF
--- a/matrix/app_server/llm/ray_serve_vllm.py
+++ b/matrix/app_server/llm/ray_serve_vllm.py
@@ -94,6 +94,8 @@ def use_ray_executor(cls, engine_config):
 
 
 class BaseDeployment:
+    lora_modules: Optional[List[LoRAModulePath]] = None
+
     def __init__(
         self,
         engine_args: AsyncEngineArgs,
@@ -407,6 +409,9 @@ class GrpcDeployment(BaseDeployment):
                 exclude_unset=True,
                 exclude_none=True,
             )
+            for choice in response_dict["choices"]:
+                if "stop_reason" in choice:
+                    choice["stop_reason"] = str(choice["stop_reason"])
             json_format.ParseDict(response_dict, response)
             return response
         except AsyncEngineDeadError as e:
@@ -463,6 +468,8 @@ class GrpcDeployment(BaseDeployment):
                 exclude_none=True,
             )
             for choice in response_dict["choices"]:
+                if "stop_reason" in choice:
+                    choice["stop_reason"] = str(choice["stop_reason"])
                 if "logprobs" in choice and "top_logprobs" in choice["logprobs"]:
                     choice["logprobs"].pop("top_logprobs")
                 if "prompt_logprobs" in choice:

--- a/matrix/client/query_llm.py
+++ b/matrix/client/query_llm.py
@@ -148,7 +148,7 @@ async def make_request(
     url: tp.Union[str, tp.Callable[[], tp.Awaitable[str]]],
     model: str,
     data: tp.Dict[str, tp.Any],
-    seed: int = 42,
+    seed: tp.Optional[int] = None,
     app_name: str = "",
     temperature: float = 0.7,
     max_tokens: int = 1024,


### PR DESCRIPTION
## Why ?

1.  set request seed default to None
2. add lora-modules as BaseDeployment attributes, to allow pass in as param from command
3. cast "stop_reason" to string as defined in openai.proto

## Test plan

end-to-end test
