### PR TITLE
add hashed app name when the name is not explicitly provided

### DIFF
--- a/matrix/app_server/app_api.py
+++ b/matrix/app_server/app_api.py
@@ -140,6 +140,13 @@ class AppApi:
                 assert applications is not None
                 for _i in range(len(applications) - 1, -1, -1):
                     app = applications[_i]
+                    if action == Action.ADD and app.get("name") is None:
+                        hex_hash = hashlib.sha256(
+                            (str(app.get("model_name")) + str(time.time())).encode()
+                        ).digest()
+                        name = base64.b32encode(hex_hash).decode()[:8]
+                        app["name"] = name
+
                     found = app.get("name") in existing_app_names
                     if found and action == Action.ADD:
                         logger.warning(


### PR DESCRIPTION
## Why ?

if no app is name is provided, add a hashed string based on model_path. otherwise it will try to match the default config, where multiple checkpoints can point to the same name
