### PR TITLE
[easy] pass timeout_min to ray head launch

### DIFF
--- a/matrix/__init__.py
+++ b/matrix/__init__.py
@@ -11,7 +11,7 @@ matrix.
 Multi-Agent daTa geneRation Infra and eXperimentation framework.
 """
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 __author__ = "FAIR"
 __credits__ = "FAIR - Meta"
 __description__ = "Multi-Agent daTa geneRation Infra and eXperimentation framework."

--- a/matrix/cluster/ray_cluster.py
+++ b/matrix/cluster/ray_cluster.py
@@ -184,7 +184,7 @@ class RayCluster:
             force_new_head (bool): force to remove head.json if haven't run 'matrix stop_cluster'.
         """
         status: tp.Dict[str, tp.Any] = {}
-        common_params = {"account", "partition", "qos", "exclusive"}
+        common_params = {"account", "partition", "qos", "exclusive", "timeout_min"}
         start_wait_time_seconds = 60
         worker_wait_timeout_seconds = 60
         requirements = slurm or local or {}

--- a/matrix/data_pipeline/classification/multi_label_classification.py
+++ b/matrix/data_pipeline/classification/multi_label_classification.py
@@ -74,8 +74,8 @@ class TextClassification:
         for prediction in predictions:
             _valid_labels: tp.List[tp.Tuple[str, float]] = []
             for label_score in prediction:
-                label = label_score["label"]
-                score = label_score["score"]
+                label = label_score["label"]  # type: ignore[index]
+                score = float(label_score["score"])  # type: ignore[index]
                 if score >= self.thresholds.get(label, 0):
                     _valid_labels.append((label, score))
             if _valid_labels:


### PR DESCRIPTION
## Why ?

currently matrix start_cluster command wont pass the timeout_min to head launch script causing invalid time error

## How ?

just add it to the common_params so that we can overwrite the default 100810 minutes from the commandline.

## Test plan

matrix start_cluster --add_workers 4 --slurm '{"partition": learnfair, "gpus_per_node": 4, "cpus_per_task": 64, "timeout_min": 1440}' --force_new_head
