### PR TITLE
Shorten 60s wait for cache in race conditions

### DIFF
--- a/matrix/client/client_utils.py
+++ b/matrix/client/client_utils.py
@@ -21,10 +21,19 @@ async def get_an_endpoint_url(
 ) -> str:
     urls = await endpoint_cache(force_update)
     start_time = time.time()
+
+    i = 0
     while not urls:
         # explicitly use synchronous sleep to block the whole event loop
-        await asyncio.sleep(60)
-        print(f"no worker is available, waited {time.time() - start_time}s..")
+        # using exponential sleep time
+        await asyncio.sleep(min(2**i, 60))
+
+        if (i := i + 1) > 4:
+            print(
+                f"worker unavail or cache locked, waited {time.time() - start_time}s..",
+                flush=True,
+            )
+
         urls = await endpoint_cache(force_update)
 
     if multiplexed_model_id:


### PR DESCRIPTION
## Why ?

When we start multiple queries in asyncio, due to the lock [here](https://github.com/facebookresearch/matrix/blob/main/matrix/client/endpoint_cache.py#L36) to avoid racing conditions, there is a mandatory 60s wait period, which makes debugging and smaller runs less effective.

<img width="838" height="150" alt="image" src="https://github.com/user-attachments/assets/b6d3acf1-0c7e-498f-a1f4-ba63996e01b0" />

## How ?

Exponential sleep starting with 1 sec and max 1 min (as before)

## Test plan

Tested locally and works -- significantly shorten the start time:

<img width="486" height="170" alt="image" src="https://github.com/user-attachments/assets/f49eec55-2a03-41e8-9922-e63e4c0152da" />

