### PR TITLE
patch: clean application names for Ray Serve compatible deployment

### DIFF
--- a/matrix/app_server/app_api.py
+++ b/matrix/app_server/app_api.py
@@ -31,7 +31,7 @@ from matrix.app_server.deploy_utils import (
 )
 from matrix.client.endpoint_cache import EndpointCache
 from matrix.common.cluster_info import ClusterInfo, get_head_http_host
-from matrix.utils.basics import convert_to_json_compatible
+from matrix.utils.basics import convert_to_json_compatible, sanitize_app_name
 from matrix.utils.os import download_s3_dir, lock_file, run_and_stream, run_async
 from matrix.utils.ray import (
     ACTOR_NAME_SPACE,
@@ -142,6 +142,14 @@ class AppApi:
                         ).digest()
                         name = base64.b32encode(hex_hash).decode()[:8]
                         app["name"] = name
+
+                    if app.get("name") is not None:
+                        sanitized = sanitize_app_name(str(app["name"]))
+                        if sanitized != app["name"]:
+                            logger.info(
+                                f"Sanitize app name {app['name']} -> {sanitized}"
+                            )
+                            app["name"] = sanitized
 
                     found = app.get("name") in existing_app_names
                     if found and action == Action.ADD:

--- a/matrix/app_server/app_api.py
+++ b/matrix/app_server/app_api.py
@@ -147,9 +147,9 @@ class AppApi:
                         sanitized = sanitize_app_name(str(app["name"]))
                         if sanitized != app["name"]:
                             logger.info(
-                                f"Sanitize app name {app['name']} -> {sanitized}"
+                                f"Sanitized app name {app['name']} -> {sanitized}"
                             )
-                        app["name"] = sanitized
+                            app["name"] = sanitized
 
                     found = app.get("name") in existing_app_names
                     if found and action == Action.ADD:

--- a/matrix/app_server/app_api.py
+++ b/matrix/app_server/app_api.py
@@ -149,7 +149,7 @@ class AppApi:
                             logger.info(
                                 f"Sanitize app name {app['name']} -> {sanitized}"
                             )
-                            app["name"] = sanitized
+                        app["name"] = sanitized
 
                     found = app.get("name") in existing_app_names
                     if found and action == Action.ADD:

--- a/matrix/utils/basics.py
+++ b/matrix/utils/basics.py
@@ -27,7 +27,8 @@ def convert_to_json_compatible(obj):
 def sanitize_app_name(app_name: str) -> str:
     """Return a Ray Serve compatible application name.
 
-    This helper removes leading and trailing slashes and replaces any remaining ``/`` characters
+    Ray Serve does not allow slashes in application names. This helper removes
+    leading and trailing slashes and replaces any remaining ``/`` characters
     with ``-`` so that user provided names can be used safely.
     """
 

--- a/matrix/utils/basics.py
+++ b/matrix/utils/basics.py
@@ -24,6 +24,16 @@ def convert_to_json_compatible(obj):
         return str(obj)
 
 
+def sanitize_app_name(app_name: str) -> str:
+    """Return a Ray Serve compatible application name.
+
+    This helper removes leading and trailing slashes and replaces any remaining ``/`` characters
+    with ``-`` so that user provided names can be used safely.
+    """
+
+    return app_name.strip("/").replace("/", "-")
+
+
 def get_user_message_from_llama3_prompt(text: str) -> str:
     PATTERN = re.compile(
         r"<\|start_header_id\|>user<\|end_header_id\|>\n\n(.*?)<\|eot_id\|>", re.DOTALL

--- a/matrix/utils/os.py
+++ b/matrix/utils/os.py
@@ -194,10 +194,11 @@ def run_and_stream(
 
     try:
         pgid = os.getpgid(pid)
+        group = str(pgid)
     except ProcessLookupError:
-        pgid = "<terminated>"
+        group = "<terminated>"
 
-    log(f"Launch process {pid} with group {pgid}")
+    log(f"Launch process {pid} with group {group}")
     if not blocking:
         return process
     else:

--- a/matrix/utils/os.py
+++ b/matrix/utils/os.py
@@ -192,7 +192,12 @@ def run_and_stream(
     output_thread = threading.Thread(target=stream_output, daemon=True)
     output_thread.start()
 
-    log(f"Launch proces {pid} with group {os.getpgid(pid)}")
+    try:
+        pgid = os.getpgid(pid)
+    except ProcessLookupError:
+        pgid = "<terminated>"
+
+    log(f"Launch process {pid} with group {pgid}")
     if not blocking:
         return process
     else:

--- a/tests/unit/utils/test_basics.py
+++ b/tests/unit/utils/test_basics.py
@@ -1,0 +1,16 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from matrix.utils.basics import sanitize_app_name
+
+
+def test_sanitize_app_name():
+    assert sanitize_app_name("meta-llama/Llama-3.1-8B") == "meta-llama-Llama-3.1-8B"
+    assert sanitize_app_name("model") == "model"
+    assert sanitize_app_name("a/b/c") == "a-b-c"
+    assert sanitize_app_name("foo/bar/baz") == "foo-bar-baz"
+    assert sanitize_app_name("/leading") == "leading"
+    assert sanitize_app_name("trailing/") == "trailing"

--- a/tests/unit/utils/test_basics.py
+++ b/tests/unit/utils/test_basics.py
@@ -14,3 +14,4 @@ def test_sanitize_app_name():
     assert sanitize_app_name("foo/bar/baz") == "foo-bar-baz"
     assert sanitize_app_name("/leading") == "leading"
     assert sanitize_app_name("trailing/") == "trailing"
+    

--- a/tests/unit/utils/test_basics.py
+++ b/tests/unit/utils/test_basics.py
@@ -14,4 +14,3 @@ def test_sanitize_app_name():
     assert sanitize_app_name("foo/bar/baz") == "foo-bar-baz"
     assert sanitize_app_name("/leading") == "leading"
     assert sanitize_app_name("trailing/") == "trailing"
-    

--- a/tests/unit/utils/test_os.py
+++ b/tests/unit/utils/test_os.py
@@ -85,5 +85,6 @@ def test_run_and_stream_handles_process_lookup_error():
         assert process is not None
         assert isinstance(process, subprocess.Popen)
 
+
 if __name__ == "__main__":
     pytest.main()

--- a/tests/unit/utils/test_os.py
+++ b/tests/unit/utils/test_os.py
@@ -77,5 +77,13 @@ def test_stop_process():
         mock_killpg.assert_called_once_with(1234, signal.SIGTERM)
 
 
+def test_run_and_stream_handles_process_lookup_error():
+    """run_and_stream should handle ProcessLookupError when logging."""
+    logger = Mock()
+    with patch("os.getpgid", side_effect=ProcessLookupError):
+        process = run_and_stream({"logger": logger}, "echo hi")
+        assert process is not None
+        assert isinstance(process, subprocess.Popen)
+
 if __name__ == "__main__":
     pytest.main()


### PR DESCRIPTION
Changes:
- Added a helper to clean application names so that slashes are removed and replaced with dashes before deployment.
- Sanitized application names during the deployment loop to avoid Ray Serve errors.
- Guarded against ProcessLookupError when logging process group IDs in subprocess handling.
- Added tests to verify the sanitization behavior for names.

Why?
- Fixes #33 
