### PR TITLE
patch: print traceback in logs upon failure of deployments

### DIFF
--- a/matrix/job/job_manager.py
+++ b/matrix/job/job_manager.py
@@ -11,6 +11,7 @@ import math
 import os
 import pickle
 import socket
+import sys
 import threading
 import time
 import traceback
@@ -93,13 +94,15 @@ def _execute_task_sequence(
                 f"[{task_id}] Deployment finished. Result: {deployment_result}"
             )
         except Exception as e:
-            logger.log.remote(f"[{task_id}] Deployment failed: {e}")
+            error_tb = traceback.format_exc()
+            logger.log.remote(f"[{task_id}] Deployment failed: {e}\n{error_tb}")
+            print(error_tb, file=sys.stderr)
             return {
                 "success": False,
                 "step": "deploy",
                 "error_type": type(e).__name__,
                 "error_message": str(e),
-                "traceback": traceback.format_exc(),
+                "traceback": error_tb,
             }
 
         # --- Step 2: Health Check ---
@@ -177,13 +180,17 @@ def _execute_task_sequence(
             return user_result
 
         except Exception as e:
-            logger.log.remote(f"[{task_id}] Exception in user task execution: {e}")
+            error_tb = traceback.format_exc()
+            logger.log.remote(
+                f"[{task_id}] Exception in user task execution: {e}\n{error_tb}"
+            )
+            print(error_tb, file=sys.stderr)
             return {
                 "success": False,
                 "step": "user_function",
                 "error_type": type(e).__name__,
                 "error_message": str(e),
-                "traceback": traceback.format_exc(),
+                "traceback": error_tb,
             }
 
     finally:
@@ -196,7 +203,9 @@ def _execute_task_sequence(
                     f"[{task_id}] Cleanup finished successfully removed {cleanup_results}."
                 )
             except Exception as e:
-                logger.log.remote(f"[{task_id}] Cleanup failed: {e}")
+                error_tb = traceback.format_exc()
+                logger.log.remote(f"[{task_id}] Cleanup failed: {e}\n{error_tb}")
+                print(error_tb, file=sys.stderr)
 
 
 # --- Job Manager Actor ---

--- a/tests/unit/job/test_job_manager.py
+++ b/tests/unit/job/test_job_manager.py
@@ -1,0 +1,63 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import sys
+from types import ModuleType
+from typing import Any, cast
+from unittest.mock import Mock, patch
+
+import pytest
+
+# provide a minimal ray stub before importing job_manager
+ray_stub = cast(Any, ModuleType("ray"))
+
+
+def remote(*_args, **_kwargs):
+    def decorator(obj):
+        return obj
+
+    return decorator
+
+
+ray_stub.remote = remote
+ray_stub.get_actor = lambda *args, **kwargs: None
+ray_stub.wait = lambda *args, **kwargs: ([], [])
+ray_stub.get = lambda obj: obj
+ray_stub.cancel = lambda *args, **kwargs: None
+sys.modules.setdefault("ray", ray_stub)
+
+from matrix.job import job_manager
+
+
+def dummy_deploy(apps):
+    return True
+
+
+def test_execute_task_sequence_prints_traceback(capsys):
+    actor = Mock()
+    actor.log.remote = Mock()
+    with patch.object(job_manager.ray, "get_actor", return_value=actor):
+
+        def user_func():
+            raise ValueError("boom")
+
+        result = job_manager._execute_task_sequence(
+            user_func,
+            [],
+            {},
+            [],
+            dummy_deploy,
+            None,
+            None,
+            1,
+            "t1",
+        )
+    assert result["success"] is False
+    assert result["step"] == "user_function"
+    err = capsys.readouterr().err
+    assert "ValueError" in err
+    assert "boom" in err
+    assert "Traceback" in err


### PR DESCRIPTION
Changes:
- Added printing of traceback details to help diagnose deployment failures when an exception occurs during app deployment.
- Logged traceback outputs for errors raised in user task execution to make worker logs more informative.
- Included traceback details in cleanup failure logging to expose more context in worker stderr files.
- Added a unit test that confirms the traceback appears on stderr when the worker encounters an error.

Why?
- Fixes #36 
