### PR TITLE
patch: replica status is converted to JSON-serializable keys before serialization

### DIFF
--- a/matrix/app_server/app_api.py
+++ b/matrix/app_server/app_api.py
@@ -274,9 +274,11 @@ class AppApi:
             results.append("\n\nReplica: " + "-" * 8)
             os.environ["RAY_ADDRESS"] = get_ray_address(self._cluster_info)
             _client = _get_global_client()
-            replicas = ray.get(_client._controller._all_running_replicas.remote())  # type: ignore[union-attr]
+            replicas = ray.get(
+                _client._controller._all_running_replicas.remote()
+            )  # type: ignore[union-attr]
             json_compatible_replicas = convert_to_json_compatible(replicas)
-            results.append((json.dumps(replicas, indent=2)))
+            results.append(json.dumps(json_compatible_replicas, indent=2))
         return results
 
     def _read_deployment(self, app_name, deployment_file, model_name=None):

--- a/tests/unit/test_app_api_status.py
+++ b/tests/unit/test_app_api_status.py
@@ -1,0 +1,77 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import sys
+import types
+from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from matrix.app_server.app_api import AppApi
+from matrix.common.cluster_info import ClusterInfo
+
+
+class DummyDeploymentID:
+    def __init__(self, name: str):
+        self.name = name
+
+    def __str__(self) -> str:
+        return f"DummyDeploymentID({self.name})"
+
+
+@dataclass
+class DummyReplica:
+    id: int
+    name: str
+
+
+@patch(
+    "matrix.app_server.app_api.run_and_stream",
+    return_value={"stdout": "", "exit_code": 0},
+)
+@patch("matrix.app_server.app_api.get_ray_address", return_value="ray://host:10001")
+@patch(
+    "matrix.app_server.app_api.get_ray_dashboard_address",
+    return_value="http://host:8265",
+)
+def test_status_replica_json_serializable(
+    mock_dashboard_addr,
+    mock_ray_addr,
+    mock_run_and_stream,
+    tmp_path,
+):
+    replica_info = DummyReplica(id=1, name="r1")
+    deployment_id = DummyDeploymentID("app")
+    replicas = {deployment_id: replica_info}
+
+    controller = MagicMock()
+    controller._all_running_replicas.remote.return_value = replicas
+    client = MagicMock()
+    client._controller = controller
+
+    dummy_context = types.SimpleNamespace(_get_global_client=lambda: client)
+    dummy_serve = types.SimpleNamespace(context=dummy_context)
+    dummy_ray = types.SimpleNamespace(get=lambda x: replicas, serve=dummy_serve)
+    with patch.dict(
+        sys.modules,
+        {
+            "ray": dummy_ray,
+            "ray.serve": dummy_serve,
+            "ray.serve.context": dummy_context,
+        },
+    ):
+        cluster_info = ClusterInfo(
+            hostname="host", client_server_port=10001, dashboard_port=8265
+        )
+        api = AppApi(str(tmp_path), cluster_info)
+
+        results = api.status(replica=True)
+        json_output = results[-1]
+        data = json.loads(json_output)
+        assert "DummyDeploymentID(app)" in data
+        assert data["DummyDeploymentID(app)"]["id"] == "1"


### PR DESCRIPTION
Changes:
- Ensures the replica status is converted to JSON-serializable keys before serialization, preventing errors when requesting replica status.
- Adds a new test that patches Ray to verify AppApi.status(replica=True) returns JSON-safe data with string keys.

Why?
- Fixes #34 