### PR TITLE
patch: mapped python API variables for the slurm deployment

### DIFF
--- a/tests/unit/cluster/test_slurm_alias.py
+++ b/tests/unit/cluster/test_slurm_alias.py
@@ -1,0 +1,17 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+from matrix.cluster.ray_cluster import _normalize_slurm_keys
+
+
+def test_normalize_slurm_keys_aliases():
+    cfg = {"slurm_account": "acc", "slurm_qos": "q"}
+    assert _normalize_slurm_keys(cfg) == {"account": "acc", "qos": "q"}
+
+
+def test_normalize_slurm_keys_passthrough():
+    cfg = {"gpus_per_node": 8}
+    assert _normalize_slurm_keys(cfg) == cfg


### PR DESCRIPTION
Changes:
- Added a mapping for “slurm_*” keys so that parameters like “slurm_account” and “slurm_qos” are automatically normalized to “account” and “qos.”
- Normalized slurm configuration before execution to handle these aliases when starting a cluster.
- Added unit tests to verify the alias normalization logic works as intended.

Why?
- Fixes #35 