### PR TITLE
Support gpt-oss model

### DIFF
--- a/matrix/app_server/llm/llm_config.py
+++ b/matrix/app_server/llm/llm_config.py
@@ -190,4 +190,24 @@ llm_model_default_parameters = {
         "gpu-memory-utilization": 0.8,
         "max_ongoing_requests": 50,
     },
+    # need to install vllm_0101_gptoss
+    "openai/gpt-oss-20b": {
+        "name": "gpt-oss-20b",
+        "tensor-parallel-size": 1,
+        "pipeline-parallel-size": 1,
+        "max-model-len": 131072,
+        "gpu-memory-utilization": 0.85,
+        "max_ongoing_requests": 64,
+        "use_v1_engine": "true",
+    },
+    # need to install vllm_0101_gptoss
+    "openai/gpt-oss-120b": {
+        "name": "gpt-oss-120b",
+        "tensor-parallel-size": 2,
+        "pipeline-parallel-size": 1,
+        "max-model-len": 131072,
+        "gpu-memory-utilization": 0.85,
+        "max_ongoing_requests": 64,
+        "use_v1_engine": "true",
+    },
 }

--- a/matrix/app_server/llm/ray_serve_vllm.py
+++ b/matrix/app_server/llm/ray_serve_vllm.py
@@ -103,8 +103,8 @@ def patched_post_init(self):
         original_post_init(self)
     except Exception as e:
         print(f"[Patch] Device detection failed: {e}, defaulting to 'cpu'")
-        self.device_type = "cpu"
-        self.device = torch.device("cpu")
+        self.device_type = "cuda"
+        self.device = torch.device("cuda")
 
 # Apply patch
 DeviceConfig.__post_init__ = patched_post_init

--- a/matrix/app_server/llm/ray_serve_vllm.py
+++ b/matrix/app_server/llm/ray_serve_vllm.py
@@ -65,10 +65,9 @@ from vllm.entrypoints.openai.serving_completion import OpenAIServingCompletion
 try:
     from vllm.entrypoints.openai.serving_engine import (  # type: ignore[attr-defined]
         LoRAModulePath,
-        PromptAdapterPath,
     )
 except:
-    from vllm.entrypoints.openai.serving_models import LoRAModulePath, PromptAdapterPath  # type: ignore[no-redef]
+    from vllm.entrypoints.openai.serving_models import LoRAModulePath  # type: ignore[no-redef]
 
 from vllm.utils import FlexibleArgumentParser
 
@@ -93,6 +92,23 @@ def use_ray_executor(cls, engine_config):
         return RayDistributedExecutor
 
 
+from vllm.config import DeviceConfig
+
+# Save original method
+original_post_init = DeviceConfig.__post_init__
+
+def patched_post_init(self):
+    import torch
+    try:
+        original_post_init(self)
+    except Exception as e:
+        print(f"[Patch] Device detection failed: {e}, defaulting to 'cpu'")
+        self.device_type = "cpu"
+        self.device = torch.device("cpu")
+
+# Apply patch
+DeviceConfig.__post_init__ = patched_post_init
+
 class BaseDeployment:
     lora_modules: Optional[List[LoRAModulePath]] = None
 
@@ -101,7 +117,6 @@ class BaseDeployment:
         engine_args: AsyncEngineArgs,
         response_role: str,
         lora_modules: Optional[List[LoRAModulePath]] = None,
-        prompt_adapters: Optional[List[PromptAdapterPath]] = None,
         request_logger: Optional[RequestLogger] = None,
         chat_template: Optional[str] = None,
         use_v1_engine: Optional[bool] = None,
@@ -112,7 +127,6 @@ class BaseDeployment:
         self.engine_args = engine_args
         self.response_role = response_role
         self.lora_modules = lora_modules
-        self.prompt_adapters = prompt_adapters
         self.request_logger = request_logger
         self.chat_template = chat_template
         self.use_v1_engine = (
@@ -189,7 +203,6 @@ class BaseDeployment:
                 model_config,
                 base_model_paths,  # type: ignore[arg-type]
                 lora_modules=self.lora_modules,
-                prompt_adapters=self.prompt_adapters,
             )
         if "chat_template_content_format" in init_params:
             kwargs["chat_template_content_format"] = "auto"
@@ -197,8 +210,6 @@ class BaseDeployment:
         # v0.6.6
         if "lora_modules" in init_params:
             kwargs["lora_modules"] = self.lora_modules
-        if "prompt_adapters" in init_params:
-            kwargs["prompt_adapters"] = self.prompt_adapters
         if "base_model_paths" in init_params:
             kwargs["base_model_paths"] = base_model_paths
 
@@ -250,7 +261,6 @@ class VLLMDeployment(BaseDeployment):
         engine_args: AsyncEngineArgs,
         response_role: str,
         lora_modules: Optional[List[LoRAModulePath]] = None,
-        prompt_adapters: Optional[List[PromptAdapterPath]] = None,
         request_logger: Optional[RequestLogger] = None,
         chat_template: Optional[str] = None,
         use_v1_engine: Optional[bool] = None,
@@ -259,7 +269,6 @@ class VLLMDeployment(BaseDeployment):
             engine_args=engine_args,
             response_role=response_role,
             lora_modules=lora_modules,
-            prompt_adapters=prompt_adapters,
             request_logger=request_logger,
             chat_template=chat_template,
             use_v1_engine=use_v1_engine,
@@ -332,7 +341,6 @@ class GrpcDeployment(BaseDeployment):
         engine_args: AsyncEngineArgs,
         response_role: str,
         lora_modules: Optional[List[LoRAModulePath]] = None,
-        prompt_adapters: Optional[List[PromptAdapterPath]] = None,
         request_logger: Optional[RequestLogger] = None,
         chat_template: Optional[str] = None,
         use_v1_engine: Optional[bool] = None,
@@ -341,7 +349,6 @@ class GrpcDeployment(BaseDeployment):
             engine_args=engine_args,
             response_role=response_role,
             lora_modules=lora_modules,
-            prompt_adapters=prompt_adapters,
             request_logger=request_logger,
             chat_template=chat_template,
             use_v1_engine=use_v1_engine,
@@ -540,7 +547,6 @@ def _build_app(cli_args: Dict[str, str], use_grpc) -> serve.Application:
         engine_args,
         parsed_args.response_role,
         parsed_args.lora_modules,
-        parsed_args.prompt_adapters,
         cli_args.get("request_logger"),
         parsed_args.chat_template,
         **deploy_args,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,12 +131,14 @@ classifiers=[
       "iopath",
       "jsonlines",
   ]
-  vllm_0100 = [
+  # For gpt-oss model with PP=1
+  vllm_0101_gptoss = [
+      # install using https://docs.vllm.ai/projects/recipes/en/latest/OpenAI/GPT-OSS.html
       "submitit>=1.5.2",
       "transformers>=4.45.2",
       "torch>=2.7.1",
-      "vllm==v0.10.0",
-      "ray[serve]==2.48.0",
+      "vllm==0.10.1+gptoss",
+      "ray[serve]>=2.48.0",
       "boto3",
       "google-genai>=1.13.0",
       "datasketch",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
   "aiohttp~=3.12",
   "requests~=2.32",
   "httpx~=0.28",
-  "openai~=1.96",
+  "openai~=1.90",
 ]
 # zip_safe = false
 classifiers=[
@@ -123,6 +123,20 @@ classifiers=[
       "torch>=2.6.0",
       "vllm==v0.8.5.post1",
       "ray[serve]==2.46.0",
+      "boto3",
+      "google-genai>=1.13.0",
+      "datasketch",
+      "s3fs",
+      "datasets",
+      "iopath",
+      "jsonlines",
+  ]
+  vllm_0100 = [
+      "submitit>=1.5.2",
+      "transformers>=4.45.2",
+      "torch>=2.7.1",
+      "vllm==v0.10.0",
+      "ray[serve]==2.48.0",
       "boto3",
       "google-genai>=1.13.0",
       "datasketch",


### PR DESCRIPTION
## Why ?

support gpt-oss model. Based on [this](https://docs.vllm.ai/projects/recipes/en/latest/OpenAI/GPT-OSS.html), the vllm support is still experimental, it seems to only work for gpt-oss models.

## How ?

add this as extra package, so it won't affect the stable release.

## Test plan

```
conda create -n matrix_gpt python==3.12
conda activate matrix_gpt
pip install uv
uv pip install -e .[vllm_0101_gptoss] \
  --extra-index-url https://wheels.vllm.ai/gpt-oss/ \
  --extra-index-url https://download.pytorch.org/whl/nightly/cu128 \
  --index-strategy unsafe-best-match

matrix deploy_applications --applications "[{'model_name': '/datasets/pretrained-llms/gpt-oss-120b', 'model_size': 'gpt-oss-120b', 'name': 'gpt120b'}, {'model_name': '/datasets/pretrained-llms/gpt-oss-20b', 'model_size': 'gpt-oss-20b', 'name': 'gpt20b'}]"

matrix inference --app_name gpt20b --input_jsonls test.jsonl --output_jsonl gpt20b_response.jsonl --batch_size=32 --system_prompt "Reasoning: high. Please reason step by step, and put your final answer within \boxed{}." --max_tokens 30000 --text_key problem --timeout_secs 3600
took 500/500 [08:00<00:00,
{'num_samples': 500, 'num_scores': 500, 'timeout_samples': 0, 'empty_samples': 2, 'acc': 90.0}

for 120b
took 500/500 [19:38<00:00
{'num_samples': 500, 'num_scores': 500, 'timeout_samples': 0, 'empty_samples': 0, 'acc': 90.8}
```