### PR TITLE
refactor: handle `stop_process` gracefully

### DIFF
--- a/matrix/utils/os.py
+++ b/matrix/utils/os.py
@@ -234,7 +234,14 @@ def stop_process(process):
     """Stops the subprocess and cleans up."""
     if process and process.poll() is None:
         print("Stopping subprocess...")
-        os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+        try:
+            pgid = os.getpgid(process.pid)
+            os.killpg(pgid, signal.SIGTERM)
+        except ProcessLookupError:
+            print(
+                f"Process group {process.pid} already terminated or does not exist"
+            )
+            return
         process.wait()
         print("Subprocess stopped.")
 

--- a/matrix/utils/os.py
+++ b/matrix/utils/os.py
@@ -238,9 +238,7 @@ def stop_process(process):
             pgid = os.getpgid(process.pid)
             os.killpg(pgid, signal.SIGTERM)
         except ProcessLookupError:
-            print(
-                f"Process group {process.pid} already terminated or does not exist"
-            )
+            print(f"Process group {process.pid} already terminated or does not exist")
             return
         process.wait()
         print("Subprocess stopped.")


### PR DESCRIPTION
Change:
- Made `stop_process` robust against missing processes by handling ProcessLookupError when killing process groups.

Why?
- Ensured `stop_process` exits early after logging a missing process group, preventing the misleading “Subprocess stopped.” message when no signal was sent.