### PR TITLE
fix: handle non-dict responses in `batch_requests`

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,19 @@ query_llm.batch_requests(
 )
 ```
 
+If you only need raw text responses, you can request text outputs directly:
+
+```python
+responses = query_llm.batch_requests(
+  url=metadata["endpoints"]["head"],
+  model=metadata["model_name"],
+  app_name=metadata["name"],
+  requests=[{"messages": [{"role": "user", "content": "hi"}]}],
+  text_response_only=True,
+)
+print(responses)
+```
+
 ---
 
 ## Job manager

--- a/matrix/client/query_llm.py
+++ b/matrix/client/query_llm.py
@@ -623,8 +623,13 @@ def batch_requests(
                 inner_resp = result["response"].get("response")
             if text_response_only:
                 if isinstance(inner_resp, dict) and inner_resp.get("error") is None:
-                    text_values = inner_resp.get("text", [])
-                    outputs[index] = text_values[0] if text_values else ""
+                    text_values = inner_resp.get("text")
+                    if isinstance(text_values, list):
+                        outputs[index] = text_values[0] if text_values else ""
+                    elif isinstance(text_values, str):
+                        outputs[index] = text_values
+                    else:
+                        outputs[index] = ""
                 else:
                     outputs[index] = ""
             if isinstance(inner_resp, dict) and inner_resp.get("error") is not None:

--- a/matrix/client/query_llm.py
+++ b/matrix/client/query_llm.py
@@ -618,12 +618,16 @@ def batch_requests(
         for result in results:
             index = result["index"]
             outputs[index] = result["response"]
+            inner_resp = None
+            if isinstance(result["response"], dict):
+                inner_resp = result["response"].get("response")
             if text_response_only:
-                if result["response"]["response"].get("error") is None:
-                    outputs[index] = result["response"]["response"]["text"][0]
+                if isinstance(inner_resp, dict) and inner_resp.get("error") is None:
+                    text_values = inner_resp.get("text", [])
+                    outputs[index] = text_values[0] if text_values else ""
                 else:
                     outputs[index] = ""
-            if result["response"]["response"].get("error") is not None:
+            if isinstance(inner_resp, dict) and inner_resp.get("error") is not None:
                 num_error += 1
 
         logger.info(f"complete {len(outputs)} samples, {num_error} request errors")

--- a/matrix/client/query_llm.py
+++ b/matrix/client/query_llm.py
@@ -582,6 +582,11 @@ def batch_requests(
           b. {"prompt": "<|start_header_id|>user<|end_header_id|>\n\n<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"}
         text_response_only: if True, return the response as a list of text. otherwise return eg
         [{"request": {...}, "response": {"text": ["..."], "finish_reason": ["..."], "response_timestamp": ..., "usage": ...}}]
+
+    Responses may also be plain strings. For example, an upstream service
+    might return "..." instead of a structured dictionary. In such
+    cases, the raw string is returned verbatim (or an empty string when
+    ``text_response_only`` is True).
     """
 
     async def _process_requests():

--- a/tests/unit/query/test_batch_requests.py
+++ b/tests/unit/query/test_batch_requests.py
@@ -153,8 +153,6 @@ def test_batch_requests_text_only_accepts_string_text():
         side_effect=mock_make_request_async,
     ):
         requests = [{}]
-        result = query_llm.batch_requests(
-            "", "", requests, text_response_only=True
-        )
+        result = query_llm.batch_requests("", "", requests, text_response_only=True)
 
         assert result == ["mocked_response"]

--- a/tests/unit/query/test_batch_requests.py
+++ b/tests/unit/query/test_batch_requests.py
@@ -110,6 +110,22 @@ def test_batch_requests_text_only_non_dict_response():
         assert result == [""]
 
 
+def test_batch_requests_non_dict_inner_response():
+    """Inner 'response' value that isn't a dict should be returned as-is."""
+
+    async def mock_make_request_async(_url, _model, request):
+        return {"response": "mocked_response"}
+
+    with patch(
+        "matrix.client.query_llm.make_request",
+        side_effect=mock_make_request_async,
+    ):
+        requests = [1]
+        result = query_llm.batch_requests("", "", requests)
+
+        assert result == [{"response": "mocked_response"}]
+
+
 def test_batch_requests_text_only_non_dict_inner_response():
     """Inner 'response' value that isn't a dict should be ignored."""
 
@@ -124,3 +140,21 @@ def test_batch_requests_text_only_non_dict_inner_response():
         result = query_llm.batch_requests("", "", requests, text_response_only=True)
 
         assert result == [""]
+
+
+def test_batch_requests_text_only_accepts_string_text():
+    """When response['text'] is a string it should be returned verbatim."""
+
+    async def mock_make_request_async(_url, _model, request):
+        return {"response": {"text": "mocked_response"}}
+
+    with patch(
+        "matrix.client.query_llm.make_request",
+        side_effect=mock_make_request_async,
+    ):
+        requests = [{}]
+        result = query_llm.batch_requests(
+            "", "", requests, text_response_only=True
+        )
+
+        assert result == ["mocked_response"]


### PR DESCRIPTION
Changes:
- Updated the `batch_requests` helper by computing the inner response once and using conditional checks to safely handle non-dictionary results from `make_request`, preventing errors.
- Added tests confirming `batch_requests` returns non-dictionary responses directly when `text_response_only` is false and gracefully handles them in text-only mode.
- Also added coverage for cases where the outer result is a dictionary but the inner `response` is not, ensuring text-only output still produces an empty string.