### PR TITLE
Add support for vision processing

### DIFF
--- a/matrix/app_server/app_api.py
+++ b/matrix/app_server/app_api.py
@@ -343,11 +343,14 @@ class AppApi:
         model = app["args"].get("model")  # type: ignore
         deployment_name = app["deployments"][0]["name"]  # type: ignore
         use_grpc = "GrpcDeployment" in deployment_name
+
         if serve_app:
             if (
                 "code" in deployment_name.lower()
                 or "hello" in deployment_name.lower()
                 or "container" in deployment_name.lower()
+                or "perception_encoder" in deployment_name.lower()
+                or "optical" in deployment_name.lower()
             ):
                 endpoint_template = f"http://{{host}}:{http_port}/{prefix}"
             else:
@@ -454,6 +457,17 @@ class AppApi:
             client = CodeExcutionClient(get_one_endpoint)
             return asyncio.run(
                 client.execute_code(
+                    output_jsonl,
+                    input_jsonls,
+                    **kwargs,
+                )
+            )
+        elif app_type in {"perception_encoder", "optical_flow"}:
+            from matrix.client.process_vision_data import VisionClient
+
+            vision_client = VisionClient(get_one_endpoint)
+            return asyncio.run(
+                vision_client.inference(
                     output_jsonl,
                     input_jsonls,
                     **kwargs,

--- a/matrix/app_server/vision/__init__.py
+++ b/matrix/app_server/vision/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.

--- a/matrix/app_server/vision/optical_flow.py
+++ b/matrix/app_server/vision/optical_flow.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import os
@@ -153,7 +154,8 @@ class OpticalFlowDeployment:
                 persistent_workers=self.num_workers > 0,
             )
 
-            result = self._calculate_motion_metrics(
+            result: Dict[str, float | List[List[float]]] = await asyncio.to_thread(
+                self._calculate_motion_metrics,
                 data_loader,
             )
 

--- a/matrix/app_server/vision/optical_flow.py
+++ b/matrix/app_server/vision/optical_flow.py
@@ -1,0 +1,213 @@
+import json
+import logging
+import os
+from argparse import ArgumentParser
+from typing import Any, Dict, List, Optional, Union
+
+import cv2
+import numpy as np
+import torch
+from fastapi import FastAPI
+from ray import get_runtime_context, serve
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from torch.utils.data import DataLoader, Dataset
+
+from matrix.app_server.vision.utils import (
+    SamplingMode,
+    TorchCodecVideoDataset,
+)
+
+logger = logging.getLogger("ray.serve")
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("openai._base_client").setLevel(logging.WARNING)
+
+TIMEOUT = 10
+
+app = FastAPI()
+
+
+@serve.deployment(
+    autoscaling_config={
+        "min_replicas": 1,
+        "target_ongoing_requests": 64,
+    },
+    ray_actor_options={"num_cpus": 4},
+    max_ongoing_requests=100,
+)
+@serve.ingress(app)
+class OpticalFlowDeployment:
+    def __init__(
+        self,
+        torch_batch_size: int = 64,
+        return_flow: bool = False,
+        motion_score: bool = True,
+    ):
+
+        self.num_workers = self._find_max_num_workers()
+        self.batch_size = torch_batch_size
+
+        self.return_flow = return_flow
+        self.calc_motion_score = motion_score
+
+    def _find_max_num_workers(self):
+        assigned_resources = get_runtime_context().get_assigned_resources()
+        num_cpus_for_replica = int(assigned_resources.get("CPU", 1))
+        num_workers = max(1, num_cpus_for_replica - 1)
+        return num_workers
+
+    def _calculate_motion_metrics(
+        self,
+        data_loader: DataLoader,
+    ) -> Dict[str, float | List[List[float]]]:
+
+        motion_scores: List[float] = []
+        optical_flows: List[np.ndarray] = []
+
+        prev_gray: np.ndarray | None = None
+
+        # Iterate through batches from the DataLoader
+        for batch in data_loader:
+            # The dataloader yields batches of tensors, shape (Batch, C, H, W)
+            video_batch_tensor = batch["frames"]
+
+            # Iterate through each frame in the batch
+            for i in range(video_batch_tensor.shape[0]):
+                frame_tensor = video_batch_tensor[i]
+
+                # --- Convert Tensor to OpenCV format ---
+                # 1. Permute from (C, H, W) to (H, W, C)
+                # 2. Convert to NumPy array
+                # 3. OpenCV expects BGR, but since we convert to grayscale, RGB vs BGR doesn't matter.
+                frame_numpy = frame_tensor.permute(1, 2, 0).numpy().astype(np.uint8)
+                gray = cv2.cvtColor(frame_numpy, cv2.COLOR_RGB2GRAY)
+
+                if prev_gray is not None:
+                    flow = cv2.calcOpticalFlowFarneback(
+                        prev_gray, gray, None, 0.5, 3, 15, 3, 5, 1.2, 0
+                    )
+
+                    if self.return_flow:
+                        optical_flows.append(flow)
+
+                    magnitude, _ = cv2.cartToPolar(flow[..., 0], flow[..., 1])
+
+                    if self.calc_motion_score:
+                        motion_scores.append(float(np.mean(magnitude)))
+
+                prev_gray = gray
+
+        scores: Dict[str, float | List[List[float]]] = {}
+
+        if self.calc_motion_score:
+            scores["motion_score"] = (
+                float(np.mean(motion_scores)) if motion_scores else 0.0
+            )
+
+        if self.return_flow:
+            scores["flow"] = [flow.tolist() for flow in optical_flows]
+
+        return scores
+
+    @app.post("/run")
+    async def run(self, request: Request) -> JSONResponse:
+
+        if request.method == "POST":
+            request_json = await request.json()
+            timeout = request_json.get("timeout", TIMEOUT)
+
+        else:
+            return JSONResponse(
+                {"error": "Data must be in JSON format!"}, status_code=400
+            )
+
+        try:
+            if "video" not in request_json:
+                raise ValueError("Request must contain 'video' field with 'file_path'.")
+
+            video_path = request_json["video"].get("file_path")
+            if video_path is None:
+                raise ValueError("Request must contain 'file_path' field in 'video'.")
+
+            start: int = request_json["video"].get("start", 0)
+            end: Optional[int] = request_json["video"].get("end", None)
+            mode: SamplingMode = request_json["video"].get("mode", SamplingMode.FRAMES)
+            sampling_rate: Optional[float] = request_json["video"].get(
+                "sampling_rate", None
+            )
+            stride: Union[int, float] = request_json["video"].get("stride", 1)
+
+            dataset = TorchCodecVideoDataset(
+                video_path=video_path,
+                start=start,
+                end=end,
+                mode=mode,
+                stride=stride,
+                sampling_rate=sampling_rate,
+            )
+            data_loader = DataLoader(
+                dataset=dataset,
+                batch_size=self.batch_size,
+                shuffle=False,
+                num_workers=self.num_workers,
+                persistent_workers=self.num_workers > 0,
+            )
+
+            result = self._calculate_motion_metrics(
+                data_loader,
+            )
+
+            return JSONResponse(
+                {
+                    "success": True,
+                    **result,
+                },
+                status_code=200,
+            )
+
+        except Exception as e:
+            return JSONResponse(
+                {
+                    "success": False,
+                    "error_msg": str(e),
+                },
+                status_code=500,
+            )
+
+
+def build_app(cli_args: Dict[str, str]) -> serve.Application:
+    """Builds the Serve app based on CLI arguments."""
+
+    argparse = ArgumentParser()
+    argparse.add_argument(
+        "--torch_batch_size",
+        type=int,
+        default=64,
+        help="Batch size for torch data loading.",
+    )
+    argparse.add_argument(
+        "--return_flow",
+        type=bool,
+        default=False,
+        help="Whether to return optical flow data.",
+    )
+    argparse.add_argument(
+        "--motion_score",
+        type=bool,
+        default=True,
+        help="motion score calculation.",
+    )
+
+    arg_strings = []
+    for key, value in cli_args.items():
+        if value is not None:
+            arg_strings.extend([f"--{key}", str(value)])
+    logger.info(arg_strings)
+
+    args = argparse.parse_args(arg_strings)
+
+    return OpticalFlowDeployment.bind(  # type: ignore[attr-defined]
+        torch_batch_size=args.torch_batch_size,
+        return_flow=args.return_flow,
+        motion_score=args.motion_score,
+    )

--- a/matrix/app_server/vision/perception_encoder.py
+++ b/matrix/app_server/vision/perception_encoder.py
@@ -1,0 +1,269 @@
+import json
+import logging
+import os
+from argparse import ArgumentParser
+from typing import Any, Dict, List, Optional, Union
+
+import core.vision_encoder.pe as pe
+import core.vision_encoder.transforms as transforms
+import torch
+import torchvision.transforms.v2 as T
+from fastapi import FastAPI
+from PIL import Image
+from ray import get_runtime_context, serve
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from torch.utils.data import DataLoader, Dataset
+
+from matrix.app_server.vision.utils import (
+    SamplingMode,
+    TorchCodecVideoDataset,
+    get_image_transform,
+)
+
+logger = logging.getLogger("ray.serve")
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("openai._base_client").setLevel(logging.WARNING)
+
+TIMEOUT = 10
+
+app = FastAPI()
+
+
+def _custom_collate_fn(batch: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Custom collate function to handle batching of video tensors and metadata.
+    """
+    # Stack all the video tensors into a single batch tensor
+    video_tensors = torch.stack([item["frames"] for item in batch], dim=0)
+
+    # Keep the metadata as a simple list of dictionaries
+    metadata_list = [item["meta"] for item in batch]
+
+    return {
+        "frames": video_tensors,
+        "meta": metadata_list,  # This is now a list of dicts, not a dict of lists/tensors
+    }
+
+
+@serve.deployment(
+    autoscaling_config={
+        "min_replicas": 1,
+        "target_ongoing_requests": 64,
+    },
+    ray_actor_options={"num_cpus": 10, "num_gpus": 1},
+    max_ongoing_requests=100,
+)
+@serve.ingress(app)
+class PerceptionEncoderDeployment:
+    def __init__(
+        self,
+        model_name: str,
+        torch_batch_size: Optional[int] = None,
+    ):
+        self.model_name = model_name
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        self.model = (
+            pe.CLIP.from_config(self.model_name, pretrained=True).to(self.device).eval()
+        )
+        self.preprocess = get_image_transform(self.model.image_size)
+
+        self.num_workers = self._find_max_num_workers()
+        self.batch_size = (
+            self._find_optimal_batch_size()
+            if torch_batch_size is None
+            else torch_batch_size
+        )
+
+    def _find_max_num_workers(self):
+        assigned_resources = get_runtime_context().get_assigned_resources()
+        num_cpus_for_replica = int(assigned_resources.get("CPU", 1))
+        num_workers = max(1, num_cpus_for_replica - 1)
+        return num_workers
+
+    def _find_optimal_batch_size(self, initial_batch_size=2048):
+        """
+        Performs a binary search to find the largest batch size that fits in GPU memory
+        by creating a dummy input tensor based on the model's configuration.
+        """
+        image_size = self.model.image_size
+
+        low = 1
+        high = initial_batch_size
+        optimal_batch_size = 0
+
+        while low <= high:
+            mid = (low + high) // 2
+            if mid == 0:
+                break
+
+            try:
+                dummy_batch = torch.zeros(
+                    (mid, 3, image_size, image_size), device=self.device
+                )
+
+                with torch.no_grad():
+                    self.model.encode_image(dummy_batch)
+
+                optimal_batch_size = mid
+                low = mid + 1
+
+            except torch.cuda.OutOfMemoryError:
+                high = mid - 1
+
+            finally:
+                # Clear cache after every attempt
+                torch.cuda.empty_cache()
+
+        return max(optimal_batch_size, 1)
+
+    @app.post("/run")
+    async def run(self, request: Request) -> JSONResponse:
+
+        if request.method == "POST":
+            request_json = await request.json()
+            timeout = request_json.get("timeout", TIMEOUT)
+
+        else:
+            return JSONResponse(
+                {"error": "Data must be in JSON format!"}, status_code=400
+            )
+
+        output = []
+        try:
+            if "video" in request_json:
+                video_path = request_json["video"].get("file_path")
+                if video_path is None:
+                    return JSONResponse(
+                        {"error": "Request must contain 'file_path' field in 'video'."},
+                        status_code=400,
+                    )
+                start: int = request_json["video"].get("start", 0)
+                end: Optional[int] = request_json["video"].get("end", None)
+                mode: SamplingMode = request_json["video"].get(
+                    "mode", SamplingMode.FRAMES
+                )
+                sampling_rate: Optional[float] = request_json["video"].get(
+                    "sampling_rate", None
+                )
+                window_size: Union[int, float] = request_json["video"].get(
+                    "window_size", 1
+                )
+                stride: Union[int, float] = request_json["video"].get("stride", 1)
+
+                dataset = TorchCodecVideoDataset(
+                    video_path=video_path,
+                    start=start,
+                    end=end,
+                    mode=mode,
+                    window_size=window_size,
+                    stride=stride,
+                    sampling_rate=sampling_rate,
+                    preprocess=self.preprocess,
+                )
+
+                batch_size = (
+                    self.batch_size
+                    if window_size <= 1
+                    else int(0.8 * self.batch_size // max(1, int(window_size)))
+                )
+
+                data_loader = DataLoader(
+                    dataset=dataset,
+                    batch_size=batch_size,
+                    shuffle=False,
+                    num_workers=self.num_workers,
+                    pin_memory=self.device == "cuda",
+                    persistent_workers=self.num_workers > 0,
+                    collate_fn=_custom_collate_fn,
+                )
+
+                with torch.no_grad():
+                    for i, batch in enumerate(data_loader):
+                        frames = batch["frames"].to(
+                            self.device, non_blocking=self.device == "cuda"
+                        )
+                        if window_size > 1:
+                            batch_embeddings = self.model.encode_video(frames)
+                        else:
+                            batch_embeddings = self.model.encode_image(frames)
+                        meta = batch["meta"]
+                        output.append(
+                            {
+                                "embeddings": batch_embeddings.cpu().tolist(),
+                                "meta": meta,
+                            }
+                        )
+
+            elif "image" in request_json:
+                image = request_json["image"]
+                image_path = image.get("file_path")
+                if image_path is None:
+                    raise ValueError(
+                        "Request must contain 'file_path' field in 'image'."
+                    )
+                if not os.path.exists(image_path):
+                    raise FileNotFoundError(f"Image file not found: {image_path}")
+
+                pil_image = Image.open(image_path).convert("RGB")
+                to_tensor_transform = T.ToTensor()
+                image_tensor = to_tensor_transform(pil_image)
+                image_tensor = (
+                    self.preprocess(image_tensor).unsqueeze(0).to(self.device)
+                )
+                with torch.no_grad():
+                    embedding = self.model.encode_image(image_tensor)
+                    embeddings = embedding.cpu().tolist()
+                output.append({"embeddings": embeddings})
+            elif "text" in request_json:
+                text = request_json["text"]
+                tokenizer = transforms.get_text_tokenizer(self.model.context_length)
+                text_tensor = tokenizer([text]).to(self.device)
+                with torch.no_grad():
+                    embedding = self.model.encode_text(text_tensor)
+                    embeddings = embedding.cpu().tolist()
+                output.append({"embeddings": embeddings})
+
+            else:
+                raise ValueError(
+                    "Request must contain either 'image', 'video' or 'text' field."
+                )
+
+            return JSONResponse(
+                {
+                    "success": True,
+                    "output": output,
+                },
+                status_code=200,
+            )
+
+        except Exception as e:
+            return JSONResponse(
+                {
+                    "success": False,
+                    "error_msg": str(e),
+                },
+                status_code=500,
+            )
+
+
+def build_app(cli_args: Dict[str, str]) -> serve.Application:
+    """Builds the Serve app based on CLI arguments."""
+
+    argparse = ArgumentParser()
+    argparse.add_argument("--model_name", type=str, required=True)
+    argparse.add_argument("--torch_batch_size", type=int, default=None)
+
+    arg_strings = []
+    for key, value in cli_args.items():
+        if value is not None:
+            arg_strings.extend([f"--{key}", str(value)])
+    logger.info(arg_strings)
+
+    args = argparse.parse_args(arg_strings)
+
+    return PerceptionEncoderDeployment.bind(  # type: ignore[attr-defined]
+        model_name=args.model_name,
+        torch_batch_size=args.torch_batch_size,
+    )

--- a/matrix/app_server/vision/utils.py
+++ b/matrix/app_server/vision/utils.py
@@ -1,0 +1,177 @@
+import logging
+import os
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import av
+import cv2
+import decord
+import numpy as np
+import torch
+import torchvision.io
+import torchvision.transforms.v2 as T
+from PIL import Image
+from torch.utils.data import Dataset
+from torchcodec.decoders import VideoDecoder
+
+logger = logging.getLogger("matrix.app_server.vision.utils")
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
+
+class SamplingMode(Enum):
+    FRAMES = "frames"
+    SECONDS = "seconds"
+
+
+class TorchCodecVideoDataset(Dataset):
+    """
+    A unified PyTorch Dataset for loading individual frames or windows (clips)
+    of frames from a video using torchcodec.
+    """
+
+    def __init__(
+        self,
+        video_path: str,
+        mode: SamplingMode = SamplingMode.FRAMES,
+        window_size: Union[int, float] = 1,
+        stride: Union[int, float] = 1,
+        sampling_rate: float = None,
+        start: Union[int, float] = None,
+        end: Union[int, float] = None,
+        preprocess=None,
+        device="cpu",
+    ):
+        super().__init__()
+        if not os.path.exists(video_path):
+            raise FileNotFoundError(f"Video file not found at: {video_path}")
+
+        self.video_path = video_path
+        self.preprocess = preprocess
+        self.device = device
+        self.sampling_rate = sampling_rate
+
+        if self.sampling_rate is not None and not 0.0 < self.sampling_rate <= 1.0:
+            raise ValueError(f"sampling_rate must be between 0.0 and 1.0")
+
+        decoder = VideoDecoder(self.video_path, device=self.device)
+        self.fps = decoder.metadata.average_fps
+        self.total_frames = decoder.metadata.num_frames
+
+        if mode == SamplingMode.SECONDS:
+            # All inputs are treated as timestamps
+            start_frame = 0 if start is None else int(start * self.fps)
+            end_frame = self.total_frames - 1 if end is None else int(end * self.fps)
+            self.window_size = max(1, int(window_size * self.fps))
+            final_stride = max(1, int(stride * self.fps))
+        else:
+            # All inputs are treated as frame indices
+            start_frame = 0 if start is None else int(start)
+            end_frame = self.total_frames - 1 if end is None else int(end)
+            self.window_size = int(window_size)
+            final_stride = int(stride)
+
+        end_frame = int(min(end_frame, self.total_frames - 1))
+
+        if start_frame >= end_frame:
+            raise ValueError(
+                f"start_frame ({start_frame}) must be less than end_frame ({end_frame})."
+            )
+
+        num_frames_in_segment = end_frame - start_frame + 1
+        if num_frames_in_segment < self.window_size:
+            raise ValueError(
+                f"Video segment ({num_frames_in_segment} frames) is smaller than window_size ({self.window_size})."
+            )
+
+        # Calculate all possible window/item start positions
+        num_items = (num_frames_in_segment - self.window_size) // final_stride + 1
+        self.item_start_frames = [
+            start_frame + (i * final_stride) for i in range(num_items)
+        ]
+
+    def _get_decoder(self):
+        """Lazy initializes the decoder for multiprocessing safety."""
+        if not hasattr(self, "decoder"):
+            self.decoder = VideoDecoder(self.video_path, device=self.device)
+        return self.decoder
+
+    def _uniform_sample(self, list_len, num_samples):
+        """Helper function to uniformly sample indices from a list."""
+        if list_len == 0:
+            return []
+        if list_len < num_samples:
+            indices = np.arange(list_len)
+            repeats = num_samples // list_len
+            remainder = num_samples % list_len
+            indices = np.concatenate([indices] * repeats + [indices[:remainder]])
+        else:
+            indices = np.linspace(0, list_len - 1, num_samples, dtype=int)
+        return indices
+
+    def __len__(self):
+        return len(self.item_start_frames)
+
+    def __getitem__(self, idx):
+        if not 0 <= idx < len(self.item_start_frames):
+            raise IndexError(f"Item index {idx} is out of bounds.")
+
+        decoder = self._get_decoder()
+
+        item_start_frame = self.item_start_frames[idx]
+        all_item_indices = list(
+            range(item_start_frame, item_start_frame + self.window_size)
+        )
+
+        if self.sampling_rate is not None:
+            num_to_sample = int(self.window_size * self.sampling_rate)
+            sample_idxs_relative = self._uniform_sample(self.window_size, num_to_sample)
+            final_indices = [all_item_indices[i] for i in sample_idxs_relative]
+            final_indices.sort()
+        else:
+            final_indices = all_item_indices
+
+        item_tensor = decoder.get_frames_at(final_indices).data
+
+        if self.preprocess:
+            processed_frames = [self.preprocess(frame) for frame in item_tensor]
+            item_tensor = torch.stack(processed_frames)
+
+        metadata = {
+            "frame_indices": final_indices,
+            "timestamps_sec": [i / self.fps for i in final_indices],
+            "source_fps": self.fps,
+            "window_idx": idx,
+            "total_frames": self.total_frames,
+        }
+
+        # If window_size is 1, return a single frame tensor, not a batch of 1
+        if self.window_size == 1 and item_tensor.shape[0] == 1:
+            return {"frames": item_tensor.squeeze(0), "meta": metadata}
+
+        return {"frames": item_tensor, "meta": metadata}
+
+
+def get_image_transform(
+    image_size: int,
+    center_crop: bool = False,
+    interpolation: T.InterpolationMode = T.InterpolationMode.BILINEAR,
+):
+    if center_crop:
+        crop = [
+            T.Resize(image_size, interpolation=interpolation),
+            T.CenterCrop(image_size),
+        ]
+    else:
+        # "Squash": most versatile
+        crop = [T.Resize((image_size, image_size), interpolation=interpolation)]
+
+    # This pipeline expects a (C, H, W) tensor of type uint8 from the decoder
+    return T.Compose(
+        crop
+        + [
+            # 1. Convert the uint8 tensor to a float tensor and scale values to [0.0, 1.0]
+            T.ToDtype(torch.float32, scale=True),
+            # 2. Normalize the float tensor to the range [-1.0, 1.0]
+            T.Normalize([0.5, 0.5, 0.5], [0.5, 0.5, 0.5], inplace=True),
+        ]
+    )

--- a/matrix/client/client_utils.py
+++ b/matrix/client/client_utils.py
@@ -3,15 +3,19 @@
 #
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
-
 import asyncio
 import hashlib
 import json
+import logging
+import os
 import random
 import time
 import typing as tp
 
 from matrix.client.endpoint_cache import EndpointCache
+
+logger = logging.getLogger("matrix.client.utils")
+logging.getLogger("httpx").setLevel(logging.WARNING)
 
 
 async def get_an_endpoint_url(
@@ -59,3 +63,19 @@ def save_to_jsonl(
             )
             json_str = json.dumps(item)
             file.write(json_str + "\n")
+
+
+def load_from_jsonl(
+    input_files: tp.Tuple[str, ...],
+) -> tp.List[tp.Dict[str, tp.Any]]:
+    data = []
+    for file_name in input_files:
+        assert os.path.exists(file_name), f"{file_name} does not exist"
+        with open(file_name, "r", encoding="UTF-8") as f:
+            num_lines = 0
+            for line_number, line in enumerate(f, start=1):
+                item = json.loads(line)
+                data.append(item)
+                num_lines += 1
+            logger.info(f"Loaded {num_lines} lines from {file_name}")
+    return data

--- a/matrix/client/process_vision_data.py
+++ b/matrix/client/process_vision_data.py
@@ -1,0 +1,205 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import asyncio
+import glob
+import json
+import logging
+import os
+import random
+import time
+import typing as tp
+
+import aiohttp
+import tqdm
+from fire import Fire
+
+from matrix.client.client_utils import (
+    get_an_endpoint_url,
+    load_from_jsonl,
+    save_to_jsonl,
+)
+from matrix.client.endpoint_cache import EndpointCache
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger("process_vision_data")
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
+
+class VisionClient:
+    def __init__(
+        self,
+        url: tp.Union[str, tp.Callable[[], tp.Awaitable[str]]],
+        timeout_secs: int = 120,
+        limit: int = 0,
+    ):
+        """
+        params:
+            url: The base URL for the http endpoint
+            timeout_secs: Per request timeout in seconds.
+            limit: max num of inputs to take (0 means all inputs).
+        """
+        self.url = url
+        self.timeout_secs = timeout_secs
+        self.limit = limit
+
+    def _validate_request(self, data: tp.Dict[str, tp.Any]) -> bool:
+        """
+        Validate the request data to ensure it contains the necessary fields.
+        """
+        keys_to_check = ("video", "image", "text")
+        if not any(key in data for key in keys_to_check):
+            logger.error(f"Request must contain at least one of {keys_to_check}.")
+            return False
+        if "video" in data:
+            if "file_path" not in data["video"]:
+                logger.error("Request must contain 'file_path' field in 'video'.")
+                return False
+        if "image" in data:
+            if "file_path" not in data["image"]:
+                logger.error("Request must contain 'file_path' field in 'image'.")
+                return False
+        return True
+
+    async def make_request(
+        self,
+        data: tp.Dict[str, tp.Any],
+        max_retries: int = 3,
+        initial_delay: int = 1,
+        backoff_factor: int = 2,
+        endpoint_cache: tp.Optional[EndpointCache] = None,
+    ) -> tp.Dict[str, tp.Any]:
+
+        assert self._validate_request(data), "Invalid request data"
+
+        if "metadata" not in data:
+            data["metadata"] = {}
+        data["metadata"]["request_timestamp"] = time.time()
+        if "timeout" not in data:
+            data["timeout"] = self.timeout_secs
+        max_retries = max(1, max_retries)
+        exception: tp.Optional[Exception] = None
+
+        for attempt in range(max_retries):
+            if callable(self.url):
+                base_url = await self.url()
+            elif not self.url and endpoint_cache:
+                url = await get_an_endpoint_url(endpoint_cache, "")
+                base_url = url
+            else:
+                base_url = self.url
+
+            assert base_url.startswith("http")
+            app_url = f"{base_url}/run"
+
+            try:
+                async with aiohttp.ClientSession() as session:
+                    async with session.post(app_url, json=data) as response:
+                        status = response.status
+                        content = await response.text()
+                        result = {
+                            "request": data,
+                            "response": {
+                                **json.loads(content),
+                                "status": status,
+                                "response_timestamp": time.time(),
+                            },
+                        }
+                        return result
+            except asyncio.TimeoutError as e:
+                exception = e
+                if attempt < max_retries - 1:
+                    delay = initial_delay * (
+                        backoff_factor**attempt + random.uniform(0, 1)
+                    )
+                    await asyncio.sleep(delay)
+                    if endpoint_cache:
+                        self.url = await get_an_endpoint_url(endpoint_cache, "", True)
+            except Exception as e:
+                exception = e
+        return {
+            "request": data,
+            "response": {
+                "error": str(exception or "unknown error"),
+                "response_timestamp": time.time(),
+            },
+        }
+
+    async def inference(
+        self,
+        output_file: str,
+        input_jsonls: str,
+        batch_size: int = 32,
+    ):
+
+        save_dir = os.path.dirname(output_file)
+        if save_dir:
+            os.makedirs(save_dir, exist_ok=True)
+        if os.path.exists(output_file):
+            logger.warning(
+                f"Output file '{output_file}' already exists, overwriting..."
+            )
+
+        input_files = glob.glob(input_jsonls)
+        if not input_files:
+            logger.error(f"No input files found matching pattern: {input_jsonls}")
+            return
+
+        lines = load_from_jsonl(tuple(input_files))
+        if self.limit <= 0:
+            limit = len(lines)
+        lines = lines[:limit]
+
+        pbar = tqdm.tqdm(total=len(lines), desc="Send request")
+
+        stats = {"success": 0, "total": 0, "sum_latency": 0}
+        pending_tasks = set()  # type: ignore
+        batch_results = []
+        append_output_file = False
+
+        async def save_outputs(flush=False):
+            nonlocal pending_tasks, batch_results, append_output_file
+            output_batch_size = 32
+
+            if pending_tasks:
+                completed, pending_tasks = await asyncio.wait(
+                    pending_tasks, return_when=asyncio.FIRST_COMPLETED
+                )
+                for completed_task in completed:
+                    batch_results.append(await completed_task)
+                    pbar.update(1)
+            if flush or len(batch_results) >= output_batch_size:
+                await asyncio.to_thread(
+                    save_to_jsonl,
+                    batch_results,
+                    output_file,
+                    "w" if not append_output_file else "a",
+                    stats,
+                )
+                batch_results = []
+                append_output_file = True
+
+        for line in lines:
+            task = asyncio.create_task(
+                self.make_request(
+                    line,
+                )
+            )
+            pending_tasks.add(task)
+            if len(pending_tasks) >= batch_size:
+                await save_outputs()
+        while pending_tasks:
+            await save_outputs()
+        if batch_results:
+            await save_outputs(flush=True)
+        pbar.close()
+        logger.info(f"Stats of the request: {stats}")
+
+
+if __name__ == "__main__":
+    Fire(VisionClient)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,22 @@ classifiers=[
       "iopath",
       "jsonlines",
   ]
+  # For video processing
+  vision = [
+      "submitit>=1.5.2",
+      "transformers>=4.45.2",
+      "vllm==v0.8.3",
+      "ray[serve]==2.43.0",
+      "torch>=2.6.0",
+      "boto3",
+      "google-genai>=1.13.0",
+      "datasketch",
+      "s3fs",
+      "datasets",
+      "iopath",
+      "jsonlines",
+      "perception_models @ git+https://github.com/facebookresearch/perception_models.git"
+  ]
 [project.scripts]
 matrix="matrix.cli:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,8 @@ classifiers=[
       "datasets",
       "iopath",
       "jsonlines",
+      "opencv-python",
+      "tenacity",
       "perception_models @ git+https://github.com/facebookresearch/perception_models.git"
   ]
 [project.scripts]


### PR DESCRIPTION
## Why ?

This PR introduces support for processing vision modalities (images and videos) in MATRIX. Users can now pass paths to images or videos, which are then encoded using a perception encoder or processed to create optical flow.

## How ?

The changes are grouped into three main categories:

**1. Efficient Video Dataset Class**
Added a video dataset class based on Torchcodec, allowing users to sample frames from videos using parameters such as start/end frame (or timestamp), window size, and sampling rate.
**2. New Applications: Perception Encoder & Optical Flow**
Optical Flow: Accepts videos and computes optical flow.
Perception Encoder: Handles text, images, or videos, returning embeddings based on user input.
**3. Vision Client**
Introduced a vision client that sends POST requests to any vision application.

## Test plan

Deploy Apps
```
matrix deploy_applications --applications '[{"name": "PE", "min_replica": 10, "max_replica": 20, "app_type": "perception_encoder", "model_name": "PE-Core-G14-448", torch_batch_size: 64}, {"name": "OP", "min_replica": 10, "max_replica": 20, "app_type": "optical_flow"}]'
```
Run Optical flow inference
```
matrix inference --app_name OP --input_jsonls '/home/yemad/Dream/input_clips.jsonl' --output_jsonl /home/yemad/Dream/output_op.jsonl --batch_size=8
cluster yemad_cluster
logging to /opt/hpcaas/.mounts/fs-072917c00f01ae1ba/home/yemad/.matrix/logs/yemad_cluster
logging to /opt/hpcaas/.mounts/fs-072917c00f01ae1ba/home/yemad/.matrix/logs/yemad_cluster
2025-08-20 19:19:33,736 - matrix.client.utils - INFO - Loaded 7 lines from /home/yemad/Dream/input_clips.jsonl
Send request: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [00:13<00:00,  1.99s/it]
2025-08-20 19:19:47,690 - process_vision_data - INFO - Stats of the request: {'success': 7, 'total': 7, 'sum_latency': 34.22414588928223}
```
Check output
```
{"request": {"text": "How big is the US?", "metadata": {"request_timestamp": 1755717573.742333}, "timeout": 120}, "response": {"success": false, "error_msg": "Request must contain 'video' field with 'file_path'.", "status": 500, "response_timestamp": 1755717573.7571507}}
{"request": {"image": {"file_path": "cat.jpg"}, "metadata": {"request_timestamp": 1755717573.7421117}, "timeout": 120}, "response": {"success": false, "error_msg": "Request must contain 'video' field with 'file_path'.", "status": 500, "response_timestamp": 1755717573.7577357}}
{"request": {"video": {"file_path": "video_1.mp4", "start": 1, "end": 5, "mode": "seconds"}, "metadata": {"request_timestamp": 1755717573.7426596}, "timeout": 120}, "response": {"success": true, "motion_score": 1.3602266907691956, "status": 200, "response_timestamp": 1755717574.0653772}}
{"request": {"video": {"file_path": "video_1.mp4", "stride": 5}, "metadata": {"request_timestamp": 1755717573.742961}, "timeout": 120}, "response": {"success": true, "motion_score": 5.878006057536348, "status": 200, "response_timestamp": 1755717575.6550617}}
{"request": {"video": {"file_path": "video_1.mp4"}, "metadata": {"request_timestamp": 1755717573.7416725}, "timeout": 120}, "response": {"success": true, "motion_score": 2.771261340155262, "status": 200, "response_timestamp": 1755717582.711773}}
{"request": {"video": {"file_path": "video_1.mp4", "window_size": 4}, "metadata": {"request_timestamp": 1755717573.7427928}, "timeout": 120}, "response": {"success": true, "motion_score": 2.771261340155262, "status": 200, "response_timestamp": 1755717582.7860982}}
{"request": {"video": {"file_path": "video_1.mp4", "start": 20, "end": 150}, "metadata": {"request_timestamp": 1755717573.7425034}, "timeout": 120}, "response": {"success": true, "motion_score": 3.4083165659354284, "status": 200, "response_timestamp": 1755717587.6879833}}
```

Run inference for Perception Encoder
```
matrix inference --app_name PE --input_jsonls '/home/yemad/Dream/input_clips.jsonl' --output_jsonl /home/yemad/Dream/output_pe.jsonl --batch_size=8
cluster yemad_cluster
logging to /opt/hpcaas/.mounts/fs-072917c00f01ae1ba/home/yemad/.matrix/logs/yemad_cluster
logging to /opt/hpcaas/.mounts/fs-072917c00f01ae1ba/home/yemad/.matrix/logs/yemad_cluster
2025-08-20 19:20:14,353 - matrix.client.utils - INFO - Loaded 7 lines from /home/yemad/Dream/input_clips.jsonl
Send request: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [01:29<00:00, 12.83s/it]
2025-08-20 19:21:44,185 - process_vision_data - INFO - Stats of the request: {'success': 7, 'total': 7, 'sum_latency': 135.15478444099426}
```
Output file is huge so couldn't paste it here.


## Notes
1. This PR introduces a vision client with a structure similar to existing clients, particularly in how inputs are read and outputs are written. I plan to submit a follow-up refactoring PR to reduce redundancies across all clients.
2. Currently, the perception encoder app uses only one GPU by default. I am running benchmarks and may update this behavior in the future, but any changes should be minimal.