### PR TITLE
fix: reordered workflow steps with proper checks

### DIFF
--- a/.github/workflows/lint_and_tests.yaml
+++ b/.github/workflows/lint_and_tests.yaml
@@ -34,11 +34,11 @@ jobs:
           python -m pip install -e '.'
           python -m pip install -e '.[dev]'
       
+      - name: pytest
+        run: pytest
       - name: isort
         run: isort --check --diff .
       - name: black
         run: black --check --diff .
-      - name: pytest
-        run: pytest || true
       - name: mypy
         run: mypy


### PR DESCRIPTION
Change:
- Reordered workflow steps: moved pytest to run before isort, black, and mypy.
- Kept pytest as strict check.

Why?
- Earlier tests are marked as passed even when failing.
- Running pytest first gives early feedback on functional correctness before enforcing style/type constraints.