### PR TITLE
update gpt_oss packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,12 +132,12 @@ classifiers=[
       "jsonlines",
   ]
   # For gpt-oss model with PP=1
-  vllm_0101_gptoss = [
+  vllm_0101 = [
       # install using https://docs.vllm.ai/projects/recipes/en/latest/OpenAI/GPT-OSS.html
       "submitit>=1.5.2",
       "transformers>=4.45.2",
       "torch>=2.7.1",
-      "vllm==0.10.1+gptoss",
+      "vllm==0.10.1",
       "ray[serve]>=2.48.0",
       "boto3",
       "google-genai>=1.13.0",


### PR DESCRIPTION
## Why ?

now vllm gpt_oss support is offical, we update https://github.com/facebookresearch/matrix/pull/54. Both gpt_oss and llama 3.3 70B works.

## How ?

update dependencies, gpt120b model is much faster than before.

## Test plan

```
conda create -n matrix_gpt_10_submit python=3.10 pip uv
conda activate matrix_gpt_10_submit
uv pip install .[vllm_0101]
matrix start_cluster --cluster_id matrix_gpt_10_submit --add_workers 1 --slurm '{"account": data, "qos": data_high}'
matrix deploy_applications --cluster_id matrix_gpt_10_submit --applications "[{'model_name': '/datasets/pretrained-llms/gpt-oss-120b', 'model_size': 'gpt-oss-120b', 'name': 'gpt120b'}, {'model_name': '/datasets/pretrained-llms/gpt-oss-20b', 'model_size': 'gpt-oss-20b', 'name': 'gpt20b'}]"

matrix inference --cluster_id matrix_gpt_10_submit --app_name gpt120b --input_jsonls test.jsonl --output_jsonl matrix_gpt_10_submit_gpt120b_response.jsonl --batch_size=32 --system_prompt "Reasoning: high. Please reason step by step, and put your final answer within \boxed{}." --max_tokens 30000 --text_key problem --timeout_secs 3600
500/500 [04:47<00:00

PYTHONPATH=. python evaluate.py --file_path ../../matrix_gpt_10_submit_gpt120b_merged_response.jsonl --parse_pred
{'num_samples': 500, 'num_scores': 500, 'timeout_samples': 0, 'empty_samples': 1, 'acc': 90.6}
```
Note: for slightly faster speed, run the following on a compute node with gpu (NOT on submit node)
uv pip install -e .[vllm_0101] --torch-backend=auto
this will install latest cudnn.
