### PR TITLE
Add Docker test image workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Ignore git and CI files
+.git
+.gitignore
+.github
+
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.so
+*.egg-info
+
+# Virtual environments
+.env
+.venv
+venv/
+ENV/
+
+# Build artifacts
+build/
+dist/
+
+# Dockerfile itself
+Dockerfile

--- a/.github/workflows/docker_image.yml
+++ b/.github/workflows/docker_image.yml
@@ -1,0 +1,32 @@
+name: Docker Test CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build test image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          build-args: MATRIX_EXTRAS=dev
+          tags: matrix-tests:${{ github.sha }}
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run tests in container
+        run: |
+          docker run --rm --entrypoint pytest matrix-tests:${{ github.sha }} -q

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.11-slim
+
+ENV PIP_NO_CACHE_DIR=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential gcc git \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY . .
+
+# Allow callers to choose which optional dependencies to install.
+ARG MATRIX_EXTRAS="vllm_083"
+RUN python -m pip install --upgrade pip setuptools wheel \
+  && python -m pip install .[${MATRIX_EXTRAS}]
+
+RUN useradd -m -u 1000 appuser && chown -R appuser:appuser /app
+USER appuser
+
+# Expose the Matrix CLI as the container entrypoint so users can execute
+# commands directly, e.g. `docker run matrix --help` or
+# `docker run matrix start_cluster ...`.
+ENTRYPOINT ["matrix"]
+CMD ["--help"]


### PR DESCRIPTION
Changes:
- Added a Dockerfile that installs dependencies and exposes the Matrix CLI as the container entrypoint.
- Introduced a workflow that builds the Docker image and runs tests in the container.

Why?
- Flexible dependency selection and direct use of the Matrix CLI through the container entrypoint.

Is it necessary?
- Nah, good to have.