### PR TITLE
Document Docker usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,15 +56,15 @@ Matrix is designed for scalable LLM inference on [Slurm](https://slurm.schedmd.c
 
 ## Getting Started
 
-- Conda Environment
-```
+- Conda Environment (Recommended)
+```bash
 conda create --name matrix python=3.10
 conda activate matrix
 pip install fair-matrix[vllm_083]
 ```
 
 - Docker
-```
+```bash
 # build the image with vLLM support (default)
 docker build -t matrix .
 
@@ -73,25 +73,25 @@ docker run --rm matrix --help
 ```
 
 - Launch ray cluster
-```
+```bash
 matrix start_cluster --add_workers 1 --slurm "{'account': $SLURM_ACCOUNT, 'qos': $SLURM_QOS}"
 ```
 
 - Deploy Model
-```
-// login to access huggingface hub
+```bash
+# login to access huggingface hub
 huggingface-cli login
 
 matrix deploy_applications --applications "[{'model_name': 'meta-llama/Llama-3.1-8B-Instruct', 'min_replica': 8, 'name': '8B'}]"
 ```
 
 - LLM Inference
-```
+```bash
 matrix check_health --app_name 8B
 ```
 
 - Shudown ray cluster
-```
+```bash
 matrix stop_cluster
 ```
 
@@ -101,28 +101,28 @@ matrix stop_cluster
 ### Enable Grafana Dashboard
 
 - Install in conda
-```
+```bash
 bash ./matrix/scripts/install_prometheus_and_grafana.sh
 ```
 - Enable in Ray Dashboard
-```
+```bash
 matrix start_cluster --enable_grafana
 ```
 
 ### Incremental Deployment
 
 - Add More Workers
-```
+```bash
 matrix start_cluster --add_workers 4 --slurm "{'account': $SLURM_ACCOUNT, 'qos': $SLURM_QOS}"
 ```
 
 - Add/Remove Applications
-```
+```bash
 matrix deploy_applications --action add --applications "[{'model_name': 'meta-llama/Llama-3.1-405B-Instruct', 'min_replica': 2, 'name': '405B'}]"
 ```
 
 - Remove All Applications
-```
+```bash
 matrix deploy_applications --applications ''
 ```
 ### Adjust Model Args
@@ -137,27 +137,27 @@ vLLM Engine [Arguments](https://docs.vllm.ai/en/latest/serving/engine_args.html)
 ### OpenAI Azure Model
 - Note: no GPU is required, in start_workers, can add `--slurm "{'gpus_per_node': 0}"`
 
-```
+```bash
 matrix deploy_applications --applications "[{'api_version': \"$AZURE_API_VERSION\", 'api_endpoint': \"$AZURE_ENDPOINT\", 'api_key': \"$AZURE_API_KEY\", 'app_type': 'openai', 'model_name': 'gpt-4o', 'name': 'openai'}]"
 ```
 
 ### Gemini
 - Note: no GPU is required, in start_workers, can add `--slurm "{'gpus_per_node': 0}"`
 
-```
+```bash
 matrix deploy_applications --applications "[{'app_type': 'gemini', 'name': "gemini", 'api_key': \"$GOOGLE_API_KEY\",  'model_name': 'gemini-2.0-flash'}]"
 ```
 
 ### Deepseek R1
 vLLM >=0.8.3 supports DS R1. An alternative backend is sglang.
-```
-// install sglang
+```bash
+# install sglang
 pip install fair-matrix[sglang_045]
 
 matrix deploy_applications --applications "[{'model_name': 'deepseek-ai/DeepSeek-R1', 'pipeline-parallel-size': 2, 'app_type': sglang_llm, 'name': 'r1'}]"
 ```
 ### Llama 4
-```
+```bash
 matrix deploy_applications --applications "[{'model_name': 'meta-llama/Llama-4-Scout-17B-16E-Instruct', 'name': 'scout'}]"
 
 matrix deploy_applications --applications "[{'model_name': 'meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8', 'name': 'maverick'}]"
@@ -168,11 +168,11 @@ matrix deploy_applications --applications "[{'model_name': 'meta-llama/Llama-4-M
 ## LLM Inference
 
 ### Batch Query
-```
-// download math-500 dataset
+```bash
+# download math-500 dataset
 python -m matrix.scripts.hf_dataset_to_jsonl HuggingFaceH4/MATH-500 test test.jsonl
 
-// query math-500
+# query math-500
 matrix inference --app_name maverick-fp8 --input_jsonls test.jsonl --output_jsonl response.jsonl --batch_size=64 \
   --system_prompt "Please reason step by step, and put your final answer within \boxed{}." --max_tokens 30000 --text_key problem --timeout_secs 1800
 ```
@@ -198,7 +198,7 @@ There are two formats for the jsonl input files:
 }
 ```
 ### Inference API
-```
+```python
 from matrix import Cli
 from matrix.client import query_llm
 
@@ -233,11 +233,11 @@ Job manager allows users to submit tasks for distributed execution on Ray. More 
 
 ### Code Execution
 - Install bubblewrap
-```
+```bash
 conda install -c conda-forge bubblewrap
 ```
 - Run example python code
-```
+```bash
 matrix deploy_applications --applications "[{'name': 'code', 'app_type': code, 'min_replica': 5}]"
 matrix check_health --app_name code
 
@@ -247,17 +247,17 @@ matrix inference code ~/tmp/he.jsonl humaneval/test.jsonl --text_keys "[prompt, 
 
 ### Data filtering and augmentation
 - minhash dedup
-```
+```bash
 python -m matrix.data_pipeline.quality.dedup_minhash $ray_head:$client_server_port input.jsonl output_dir working_dir --text_key problem
 ```
 - multilabel classification
-```
+```bash
 python -m matrix.data_pipeline.classification.multi_label_classification $ray_head:$client_server_port  \
   cardiffnlp/twitter-roberta-base-emotion-multilabel-latest input.jsonl output_dir \
   --num_gpus 8 --text_key question --threshold_fname ""
 ```
 - Offline batch inference
-```
+```bash
 python -m matrix.data_pipeline.generate.vllm_generate $ray_head:$client_server_port ./math-500/test.jsonl math-500/response  \
   --prompt_template "<|start_header_id|>system<|end_header_id|>\n\nPlease reason step by step, and put your final answer within \boxed{}.<|eot_id|><|start_header_id|>user<|end_header_id|>\n\n<user_message><|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n" \
   --model_args "{'model': 'meta-llama/Llama-3.3-70B-Instruct', 'seed': 42, 'max_model_len': 20480, 'tensor_parallel_size': 4}" \
@@ -276,7 +276,7 @@ feel free to email Dong Wang (dongwang@meta.com) or Daniel Li (shangwel@meta.com
 If you use matrix in your research and wish to refer to it, please use the
 following BibTeX entry.
 
-```
+```bibtex
 @software{matrix2025,
   author = {Dong Wang and Yang Li and Ansong Ni and Youssef Emad and Xinjie Lei and Ruta Desai and Karthik Padthe and Xian Li and Asli Celikyilmaz and Ramya Raghavendra and Leo Huang and Daniel Li},
   title = {Matrix: Multi-Agent daTa geneRation Infra and eXperimentation},

--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ conda activate matrix
 pip install fair-matrix[vllm_083]
 ```
 
+- Docker
+```
+# build the image with vLLM support (default)
+docker build -t matrix .
+
+# run any Matrix CLI command, e.g. display help
+docker run --rm matrix --help
+```
+
 - Launch ray cluster
 ```
 matrix start_cluster --add_workers 1 --slurm "{'account': $SLURM_ACCOUNT, 'qos': $SLURM_QOS}"


### PR DESCRIPTION
Change:
- Documented how to build the image and run Matrix commands via Docker in the README.

Why?
- Forgot to include it in #70 