### PR TITLE
updated configuration names as huggingface

### DIFF
--- a/matrix/app_server/llm/llm_config.py
+++ b/matrix/app_server/llm/llm_config.py
@@ -145,7 +145,7 @@ llm_model_default_parameters = {
         "max-model-len": 32768,
         "gpu-memory-utilization": 0.8,
     },
-    "Qwen2.5-32B-Instruct": {
+    "Qwen/Qwen2.5-32B-Instruct": {
         "name": "Qwen2.5-32B",
         "tensor-parallel-size": 2,
         "pipeline-parallel-size": 1,
@@ -154,7 +154,7 @@ llm_model_default_parameters = {
         "max-model-len": 131072,
         "gpu-memory-utilization": 0.8,
     },
-    "Qwen2.5-72B-Instruct": {
+    "Qwen/Qwen2.5-72B-Instruct": {
         "name": "Qwen2.5-72B",
         "tensor-parallel-size": 4,
         "pipeline-parallel-size": 1,
@@ -163,7 +163,7 @@ llm_model_default_parameters = {
         "max-model-len": 131072,
         "gpu-memory-utilization": 0.8,
     },
-    "Qwen3-8B": {
+    "Qwen/Qwen3-8B": {
         "name": "Qwen3-8B",
         "tensor-parallel-size": 1,
         "pipeline-parallel-size": 1,
@@ -172,8 +172,8 @@ llm_model_default_parameters = {
         "max-model-len": 131072,
         "gpu-memory-utilization": 0.8,
     },
-    "Qwen3-32B": {
-        "name": "Qwen3-8B",
+    "Qwen/Qwen3-32B": {
+        "name": "Qwen3-32B",
         "tensor-parallel-size": 2,
         "pipeline-parallel-size": 1,
         "enable-prefix-caching": True,


### PR DESCRIPTION
Changes:
- Updated Qwen model configuration names as in huggingface. Also updated name `32B` instead of `8B` for `Qwen/Qwen3-32B`.

Why?
- Fixes #72 