### PR TITLE
override the openai_harmony tiktoken-rs-cache

### DIFF
--- a/matrix/app_server/deploy_utils.py
+++ b/matrix/app_server/deploy_utils.py
@@ -72,6 +72,7 @@ vllm_app_template = """
     env_vars:
         OUTLINES_CACHE_DIR: {{ temp_dir }}/.outlines
         RAY_DEBUG: legacy
+        TIKTOKEN_CACHE_DIR: {{ temp_dir }}/.tiktoken-rs-cache
   args:
     model: {{ app.model_name }}
     {% for key, value in app.items() %}

--- a/matrix/app_server/deploy_utils.py
+++ b/matrix/app_server/deploy_utils.py
@@ -72,7 +72,7 @@ vllm_app_template = """
     env_vars:
         OUTLINES_CACHE_DIR: {{ temp_dir }}/.outlines
         RAY_DEBUG: legacy
-        TIKTOKEN_CACHE_DIR: {{ temp_dir }}/.tiktoken-rs-cache
+        TIKTOKEN_RS_CACHE_DIR: {{ temp_dir }}
   args:
     model: {{ app.model_name }}
     {% for key, value in app.items() %}


### PR DESCRIPTION
## Why ?

vllm gpt-oss use openai_harmony package, which use a cache dir by default /tmp/tiktoken-rs-cache, however, this directory is shared and prevent multi users running on same node.

```
            File "/checkpoint/data/shared/conda/matrix_gpt_oss/lib/python3.10/site-packages/openai_harmony/__init__.py", line 689, in load_harmony_encoding
              inner: _PyHarmonyEncoding = _load_harmony_encoding(name)
          openai_harmony.HarmonyError: error downloading or loading vocab file: an underlying IO error occurred while creating file "/tmp/tiktoken-rs-cache/fb374d419588a4632f3f557e76b4b70aebbca790": Permission denied (os error 13)
```
## How ?

override using env to a per cluster tmp dir.

## Test plan

matrix --cluster_id matrix_gpt_oss check_health --app_name gpt120b
