### PR TITLE
refactor: enhanced `convert_to_json_compatible` function

### DIFF
--- a/matrix/utils/basics.py
+++ b/matrix/utils/basics.py
@@ -6,22 +6,28 @@
 
 import importlib
 import re
-from dataclasses import asdict
+from dataclasses import asdict, is_dataclass
+from enum import Enum
+from typing import Any
 
 import matrix
 
 
-def convert_to_json_compatible(obj):
+def convert_to_json_compatible(obj: Any):
     if isinstance(obj, dict):
         return {
             str(key): convert_to_json_compatible(value) for key, value in obj.items()
         }
-    elif isinstance(obj, list):
+    if isinstance(obj, (list, tuple, set)):
         return [convert_to_json_compatible(item) for item in obj]
-    elif hasattr(obj, "__dataclass_fields__"):
+    if is_dataclass(obj):
         return convert_to_json_compatible(asdict(obj))
-    else:
-        return str(obj)
+    if isinstance(obj, Enum):
+        return convert_to_json_compatible(obj.value)
+    if isinstance(obj, (str, int, float, bool)) or obj is None:
+        return obj
+
+    return str(obj)
 
 
 def sanitize_app_name(app_name: str) -> str:

--- a/matrix/utils/basics.py
+++ b/matrix/utils/basics.py
@@ -20,7 +20,7 @@ def convert_to_json_compatible(obj: Any):
         }
     if isinstance(obj, (list, tuple, set)):
         return [convert_to_json_compatible(item) for item in obj]
-    if is_dataclass(obj):
+    if is_dataclass(obj) and not isinstance(obj, type):
         return convert_to_json_compatible(asdict(obj))
     if isinstance(obj, Enum):
         return convert_to_json_compatible(obj.value)

--- a/tests/unit/test_app_api_status.py
+++ b/tests/unit/test_app_api_status.py
@@ -74,4 +74,4 @@ def test_status_replica_json_serializable(
         json_output = results[-1]
         data = json.loads(json_output)
         assert "DummyDeploymentID(app)" in data
-        assert data["DummyDeploymentID(app)"]["id"] == "1"
+        assert data["DummyDeploymentID(app)"]["id"] == 1

--- a/tests/unit/utils/test_basics.py
+++ b/tests/unit/utils/test_basics.py
@@ -4,7 +4,10 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from matrix.utils.basics import sanitize_app_name
+from dataclasses import dataclass
+from enum import Enum
+
+from matrix.utils.basics import convert_to_json_compatible, sanitize_app_name
 
 
 def test_sanitize_app_name():
@@ -14,3 +17,42 @@ def test_sanitize_app_name():
     assert sanitize_app_name("foo/bar/baz") == "foo-bar-baz"
     assert sanitize_app_name("/leading") == "leading"
     assert sanitize_app_name("trailing/") == "trailing"
+
+
+class Color(Enum):
+    RED = "red"
+    BLUE = "blue"
+
+
+@dataclass
+class Demo:
+    """Small dataclass used to validate JSON conversion."""
+
+    a: int
+    b: tuple[int, ...]
+    c: set[str]
+    color: Color
+
+
+def test_convert_to_json_compatible_handles_types():
+    data = {
+        "int": 1,
+        "float": 1.5,
+        "bool": True,
+        "none": None,
+        "tuple": (1, 2),
+        "set": {"x", "y"},
+        "dc": Demo(5, (3, 4), {"z"}, Color.RED),
+        "enum": Color.BLUE,
+    }
+
+    converted = convert_to_json_compatible(data)
+
+    assert converted["int"] == 1
+    assert converted["float"] == 1.5
+    assert converted["bool"] is True
+    assert converted["none"] is None
+    assert converted["tuple"] == [1, 2]
+    assert sorted(converted["set"]) == ["x", "y"]
+    assert converted["dc"] == {"a": 5, "b": [3, 4], "c": ["z"], "color": "red"}
+    assert converted["enum"] == "blue"

--- a/tests/unit/utils/test_basics.py
+++ b/tests/unit/utils/test_basics.py
@@ -56,3 +56,8 @@ def test_convert_to_json_compatible_handles_types():
     assert sorted(converted["set"]) == ["x", "y"]
     assert converted["dc"] == {"a": 5, "b": [3, 4], "c": ["z"], "color": "red"}
     assert converted["enum"] == "blue"
+
+
+def test_convert_to_json_compatible_dataclass_class():
+    """Ensure dataclass *types* are stringified rather than treated as instances."""
+    assert convert_to_json_compatible(Demo) == str(Demo)


### PR DESCRIPTION
Changes:
- Enhanced `convert_to_json_compatible` to retain primitive types, convert tuples and sets to lists, and document its behavior for JSON encoding, ensuring broader compatibility.
- Added tests covering numeric, boolean, tuple, set, and dataclass scenarios, and updated replica status expectations to reflect preserved integer types.

Why?
- The previous implementation was overly eager in stringifying values which meant that integers, floats or booleans would be converted to strings. This is undesirable because downstream consumers expect to preserve the original data types.
