### PR TITLE
Make container Service more robust

### DIFF
--- a/matrix/app_server/app_api.py
+++ b/matrix/app_server/app_api.py
@@ -511,3 +511,13 @@ class AppApi:
                     return "RUNNING"
             except:
                 return "NOT_STARTED"
+
+    def app_cleanup(self, app_name: str) -> str:
+        """A helper function to cleanup for stateful services, eg containers maybe be dangling due to exception etc."""
+        from matrix.client.container_client import ContainerClient
+
+        metadata = self.get_app_metadata(app_name)
+        assert metadata["app_type"] == "container"
+        base_url = metadata["endpoints"]["head"]
+        client = ContainerClient(base_url)
+        return run_async(client.release_all_containers())

--- a/matrix/app_server/container/container_deployment.py
+++ b/matrix/app_server/container/container_deployment.py
@@ -227,7 +227,7 @@ class ContainerDeployment:
         self.num_containers_per_replica = num_containers_per_replica
 
         # create local non-detached actors and register them
-        self.local_actors = []  # actor ids hex owned by this replica
+        self.local_actors: list[Any] = []  # actor ids hex owned by this replica
         # Cancellation event
         self._stop_event = threading.Event()
 
@@ -240,7 +240,7 @@ class ContainerDeployment:
         for _ in range(self.num_containers_per_replica):
             if self._stop_event.is_set():
                 break
-            actor_handle = ContainerActor.remote()
+            actor_handle = ContainerActor.remote()  # type: ignore[attr-defined]
             while not self._stop_event.is_set():
                 try:
                     # Use non-blocking wait with timeout

--- a/matrix/app_server/container/container_deployment.py
+++ b/matrix/app_server/container/container_deployment.py
@@ -147,7 +147,7 @@ class ContainerActor:
         cwd: str = "",
         env: dict[str, str] = None,
         forward_env: list[str] = None,
-        timeout: int | None = None,
+        timeout: int | None = None,  # in seconds
     ) -> dict[str, Any]:
         """Run a command inside the running instance."""
         if self.config is None:

--- a/matrix/app_server/deploy_utils.py
+++ b/matrix/app_server/deploy_utils.py
@@ -195,12 +195,12 @@ other_app_template = """
   import_path: matrix.app_server.container.container_deployment:build_app
   runtime_env: {}
   args:
-    num_containers_per_replica: {{ app.num_containers_per_replica }}
+    num_containers_per_replica: {{ app.max_ongoing_requests }}
   deployments:
   - name: ContainerDeployment
-    max_ongoing_requests: 32
+    max_ongoing_requests: {{ app.max_ongoing_requests }}
     autoscaling_config:
-      target_ongoing_requests: 32
+      target_ongoing_requests: {{ (app.max_ongoing_requests * 0.8) | int }}
       min_replicas: {{ app.min_replica }}
       max_replicas: {{ app.max_replica }}
 {% elif app.app_type == 'hello' %}
@@ -384,7 +384,6 @@ def get_yaml_for_deployment(
                 default_params: Dict[str, Union[str, int]] = {
                     "name": "container",
                     "max_ongoing_requests": 32,
-                    "num_containers_per_replica": 32,
                 }
                 app.update({k: v for k, v in default_params.items() if k not in app})
                 yaml_str += Template(other_app_template).render(app=app)

--- a/matrix/app_server/llm/ray_serve_vllm.py
+++ b/matrix/app_server/llm/ray_serve_vllm.py
@@ -293,6 +293,8 @@ class VLLMDeployment(BaseDeployment):
             request, raw_request
         )
         if isinstance(generator, ErrorResponse):
+            if hasattr(generator, "error"):
+                generator = generator.error
             return JSONResponse(
                 content=generator.model_dump(exclude_unset=True, exclude_none=True),
                 status_code=generator.code,

--- a/matrix/app_server/llm/ray_serve_vllm.py
+++ b/matrix/app_server/llm/ray_serve_vllm.py
@@ -319,6 +319,8 @@ class VLLMDeployment(BaseDeployment):
             request, raw_request
         )
         if isinstance(generator, ErrorResponse):
+            if hasattr(generator, "error"):
+                generator = generator.error
             return JSONResponse(
                 content=generator.model_dump(), status_code=generator.code
             )
@@ -408,6 +410,8 @@ class GrpcDeployment(BaseDeployment):
                 await self.openai_serving_chat.models.init_static_loras()
             generator = await self.openai_serving_chat.create_chat_completion(chat)
             if isinstance(generator, ErrorResponse):
+                if hasattr(generator, "error"):
+                    generator = generator.error
                 status_code = self.http_to_grpc_status(generator.code)
                 raise grpc.RpcError(
                     status_code,
@@ -465,6 +469,8 @@ class GrpcDeployment(BaseDeployment):
                 ),
             )
             if isinstance(generator, ErrorResponse):
+                if hasattr(generator, "error"):
+                    generator = generator.error
                 status_code = self.http_to_grpc_status(generator.code)
                 raise grpc.RpcError(
                     status_code,

--- a/matrix/cli.py
+++ b/matrix/cli.py
@@ -322,12 +322,11 @@ class Cli:
                         ManagedContainer,
                     )
 
-                    client = ContainerClient(metadata["endpoints"]["head"])
                     async with ManagedContainer(
-                        client, image="docker://ubuntu:22.04"
-                    ) as container_id:
-                        assert container_id is not None
-                        return await client.execute(container_id, "echo Hello World")
+                        ContainerClient(metadata["endpoints"]["head"]),
+                        image="docker://ubuntu:22.04",
+                    ) as client:
+                        return await client.execute("echo Hello World")
 
                 return run_async(run_container())
             else:

--- a/matrix/client/container_client.py
+++ b/matrix/client/container_client.py
@@ -44,6 +44,7 @@ class ContainerClient:
             raise ContainerClientError(f"Request failed: {content}")
 
         if status >= 400:
+            print(f"Error response from server: {content}")
             try:
                 error_data = json.loads(content)
                 detail = error_data.get("detail", content)

--- a/matrix/client/container_client.py
+++ b/matrix/client/container_client.py
@@ -44,46 +44,51 @@ class ContainerClient:
         self.base_url = base_url.rstrip("/")
         self.containers: list[str] = []
 
-    def _parse_response(self, status: Optional[int], content: str) -> Dict:
-        """Parse response content and handle errors."""
+    async def _handle_response(
+        self, status: Optional[int], content: str
+    ) -> Dict[str, Any]:
+        """Handle HTTP response and convert to standardized format."""
         if status is None:
-            raise ContainerClientError(f"Request failed: {content}")
-
-        if status >= 400:
-            print(f"Error response from server: {content}")
-            try:
-                error_data = json.loads(content)
-                detail = error_data.get("detail", content)
-            except json.JSONDecodeError:
-                detail = content
-            raise ContainerClientError(f"HTTP {status}: {detail}", status_code=status)
+            # Network or connection error
+            return {"error": content}
 
         try:
-            return json.loads(content)
+            # Try to parse JSON response
+            response_data = json.loads(content)
+
+            # Check if it's an HTTP error status
+            if status >= 400:
+                if isinstance(response_data, dict) and "detail" in response_data:
+                    return {"error": response_data["detail"]}
+                else:
+                    return {"error": f"HTTP {status}: {content}"}
+
+            return response_data
+
         except json.JSONDecodeError:
-            raise ContainerClientError(f"Invalid JSON response: {content}")
+            if status >= 400:
+                return {"error": f"HTTP {status}: {content}"}
+            else:
+                return {"error": f"Invalid JSON response: {content}"}
 
     async def acquire_container(
         self,
         image: str,
         executable: str = "apptainer",
         run_args: Optional[List[str]] = None,
-        timeout: int = 300,
-    ) -> str | None:
+        timeout: Optional[int] = None,
+    ) -> Dict[str, Any]:
         """
-        Acquire a container with the specified image.
+        Acquire a new container.
 
         Args:
             image: Container image (e.g., "docker://ubuntu:22.04")
             executable: Container runtime executable (default: "apptainer")
-            run_args: Additional runtime arguments (default: [])
-            timeout: Timeout in seconds to wait for available container (default: 5.0)
+            run_args: Additional arguments for container run (default: [])
+            timeout: Timeout for container acquisition
 
         Returns:
-            Container ID string
-
-        Raises:
-            ContainerClientError: If acquisition fails
+            Dict with either {"container_id": "..."} or {"error": "..."}
         """
         if run_args is None:
             run_args = []
@@ -95,62 +100,30 @@ class ContainerClient:
             "timeout": timeout,
         }
 
-        url = f"{self.base_url}/acquire"
+        session_timeout = aiohttp.ClientTimeout(total=timeout + 5) if timeout else None
+        async with aiohttp.ClientSession(timeout=session_timeout) as session:
+            status, content = await post_url(
+                session, f"{self.base_url}/acquire", payload
+            )
+            return await self._handle_response(status, content)
 
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(timeout)) as session:
-            status, content = await post_url(session, url, payload)
-            response = self._parse_response(status, content)
-            container_id = response.get("container_id")
-            if container_id:
-                self.containers.append(container_id)
-
-            return container_id
-
-    async def release_container(
-        self, container_id: str, timeout: int | None = None
-    ) -> Dict:
+    async def release_container(self, container_id: str) -> Dict[str, Any]:
         """
-        Release a container by its ID.
+        Release a container.
 
         Args:
             container_id: ID of the container to release
 
         Returns:
-            Response dictionary with status and container_id
-
-        Raises:
-            ContainerClientError: If release fails
+            Dict with either {"container_id": "..."} or {"error": "..."}
         """
         payload = {"container_id": container_id}
-        url = f"{self.base_url}/release"
 
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(timeout)) as session:
-            status, content = await post_url(session, url, payload)
-            result = self._parse_response(status, content)
-            if container_id in self.containers:
-                self.containers.remove(container_id)
-            return result
-
-    async def release_all(self, timeout: int | None = None) -> Dict:
-        """
-        Release all containers owned by this client.
-
-        Args:
-            timeout: Timeout in seconds for the release operation (default: None)
-
-        Returns:
-            Response dictionary with status and released container IDs
-
-        Raises:
-            ContainerClientError: If release fails
-        """
-        url = f"{self.base_url}/release_all"
-
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(timeout)) as session:
-            status, content = await post_url(session, url, {})
-            result = self._parse_response(status, content)
-            self.containers.clear()
-            return result
+        async with aiohttp.ClientSession() as session:
+            status, content = await post_url(
+                session, f"{self.base_url}/release", payload
+            )
+            return await self._handle_response(status, content)
 
     async def execute(
         self,
@@ -159,53 +132,61 @@ class ContainerClient:
         cwd: Optional[str] = None,
         env: Optional[Dict[str, str]] = None,
         forward_env: Optional[List[str]] = None,
-        timeout: int | None = None,  # wait indefinitely
-    ) -> Dict:
+        timeout: int = 30,
+    ) -> Dict[str, Any]:
         """
-        Execute a command in the specified container.
+        Execute a command in a container.
 
         Args:
-            container_id: ID of the container to execute command in
+            container_id: ID of the container
             cmd: Command to execute
-            cwd: Working directory for the command (optional)
-            env: Environment variables to set (optional)
-            forward_env: List of environment variables to forward from host (optional)
+            cwd: Working directory for command execution
+            env: Environment variables to set
+            forward_env: Environment variables to forward from host
+            timeout: Command timeout in seconds (default: 30)
 
         Returns:
-            Execution result dictionary
-
-        Raises:
-            ContainerClientError: If execution fails
+            Dict with either {"returncode": int, "output": str} or {"error": "..."}
         """
-        payload: Dict[str, Any] = {"container_id": container_id, "cmd": cmd}
-
+        payload = {"container_id": container_id, "cmd": cmd, "timeout": timeout}
         if cwd is not None:
             payload["cwd"] = cwd
         if env is not None:
             payload["env"] = env
         if forward_env is not None:
             payload["forward_env"] = forward_env
-        payload["timeout"] = timeout
 
-        url = f"{self.base_url}/execute"
+        session_timeout = aiohttp.ClientTimeout(total=timeout + 5) if timeout else None
+        async with aiohttp.ClientSession(timeout=session_timeout) as session:
+            status, content = await post_url(
+                session, f"{self.base_url}/execute", payload
+            )
+            return await self._handle_response(status, content)
 
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(timeout)) as session:
-            status, content = await post_url(session, url, payload)
-            return self._parse_response(status, content)
-
-    async def get_status(self) -> Dict:
+    async def get_status(self) -> Dict[str, Any]:
         """
-        Get the current status of the container deployment.
+        Get status of all containers and actors.
 
         Returns:
-            Status information dictionary
-
-        Raises:
-            ContainerClientError: If status request fails
+            Dict with either {"actors": {...}, "containers": {...}} or {"error": "..."}
         """
-        url = f"{self.base_url}/status"
-        status, content = await fetch_url(url)
-        return self._parse_response(status, content)
+        status, content = await fetch_url(f"{self.base_url}/status")
+        return await self._handle_response(status, content)
+
+    async def release_all_containers(self) -> Dict[str, Any]:
+        """
+        Release all containers.
+
+        Returns:
+            Dict with either {"container_ids": []} or {"error": "..."}
+        """
+        payload = {}
+
+        async with aiohttp.ClientSession() as session:
+            status, content = await post_url(
+                session, f"{self.base_url}/release_all", payload
+            )
+            return await self._handle_response(status, content)
 
     async def __aenter__(self):
         return self
@@ -239,13 +220,16 @@ class ManagedContainer:
 
     async def __aenter__(self) -> str | None:
         """Acquire container on entering context."""
-        self.container_id = await self.client.acquire_container(
+        result = await self.client.acquire_container(
             image=self.image,
             executable=self.executable,
             run_args=self.run_args,
             timeout=self.timeout,
         )
-        return self.container_id
+        if "error" in result:
+            raise Exception(f"Failed to acquire container: {result['error']}")
+        self.container_id = result["container_id"]
+        return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         """Release container on exiting context."""
@@ -255,6 +239,18 @@ class ManagedContainer:
             except ContainerClientError:
                 # Log error but don't raise - we're already exiting
                 pass
+
+    async def execute(
+        self,
+        cmd: str,
+        cwd: Optional[str] = None,
+        env: Optional[Dict[str, str]] = None,
+        forward_env: Optional[List[str]] = None,
+        timeout: int = 30,
+    ) -> Dict[str, Any]:
+        return await self.client.execute(
+            self.container_id, cmd, cwd, env, forward_env, timeout
+        )
 
 
 if __name__ == "__main__":
@@ -274,7 +270,10 @@ if __name__ == "__main__":
                     for tag in tags
                 ],
             )
-            containers = [cid for cid in containers if not isinstance(cid, Exception)]
+            print(containers)
+            containers = [
+                cid["container_id"] for cid in containers if "error" not in cid
+            ]
             await batch_requests_async(
                 client.execute,
                 [

--- a/matrix/client/container_client.py
+++ b/matrix/client/container_client.py
@@ -180,11 +180,9 @@ class ContainerClient:
         Returns:
             Dict with either {"container_ids": []} or {"error": "..."}
         """
-        payload = {}
-
         async with aiohttp.ClientSession() as session:
             status, content = await post_url(
-                session, f"{self.base_url}/release_all", payload
+                session, f"{self.base_url}/release_all", {}
             )
             return await self._handle_response(status, content)
 
@@ -218,7 +216,7 @@ class ManagedContainer:
         self.timeout = timeout
         self.container_id: Optional[str] = None
 
-    async def __aenter__(self) -> str | None:
+    async def __aenter__(self) -> "ManagedContainer":
         """Acquire container on entering context."""
         result = await self.client.acquire_container(
             image=self.image,
@@ -248,6 +246,7 @@ class ManagedContainer:
         forward_env: Optional[List[str]] = None,
         timeout: int = 30,
     ) -> Dict[str, Any]:
+        assert self.container_id is not None, "Container not acquired yet"
         return await self.client.execute(
             self.container_id, cmd, cwd, env, forward_env, timeout
         )

--- a/matrix/utils/http.py
+++ b/matrix/utils/http.py
@@ -7,7 +7,6 @@
 import aiohttp
 import requests
 
-
 async def post_url(session, url, data=None):
     """Send a POST request to a given URL with optional data, returning status and content."""
     try:
@@ -16,7 +15,7 @@ async def post_url(session, url, data=None):
             content = await response.text()  # Get the response body as text
             return status, content
     except Exception as e:
-        return None, str(e)  # Return None for status and error message as content
+        return None, repr(e)  # Return None for status and error message as content
 
 
 async def fetch_url(url, headers=None):

--- a/matrix/utils/http.py
+++ b/matrix/utils/http.py
@@ -7,6 +7,7 @@
 import aiohttp
 import requests
 
+
 async def post_url(session, url, data=None):
     """Send a POST request to a given URL with optional data, returning status and content."""
     try:

--- a/matrix/utils/ray.py
+++ b/matrix/utils/ray.py
@@ -8,6 +8,7 @@ import json
 import os
 import subprocess
 import time
+import typing as tp
 from enum import Enum
 from functools import partial
 
@@ -149,7 +150,7 @@ async def ray_get_async(ref, timeout=None):
 
         def wait_for_all():
 
-            results = [None] * len(ref)
+            results: list[tp.Any] = [None] * len(ref)
             done = [False] * len(ref)
             remaining = ref[:]
             ref_to_index = {r: i for i, r in enumerate(ref)}
@@ -172,6 +173,7 @@ async def ray_get_async(ref, timeout=None):
                         done[idx] = True
                     except Exception as e:
                         results[idx] = e
+                        done[idx] = True
 
             for i, finish in enumerate(done):
                 if not finish:

--- a/matrix/utils/ray.py
+++ b/matrix/utils/ray.py
@@ -7,7 +7,9 @@
 import json
 import os
 import subprocess
+import time
 from enum import Enum
+from functools import partial
 
 import aiohttp
 
@@ -129,3 +131,60 @@ def status_is_failure(app_status: str) -> bool:
 
 def status_is_pending(app_status: str) -> bool:
     return app_status in ["NOT_STARTED", "DEPLOYING", "UNHEALTHY"]
+
+
+async def ray_get_async(ref, timeout=None):
+    # helper to await ray.get/ray.wait without blocking the async loop
+    import asyncio
+
+    import ray
+
+    loop = asyncio.get_event_loop()
+
+    # If ref is a list, use ray.wait to get all results
+    if isinstance(ref, list):
+        assert len(ref) > 0
+        if timeout is None:
+            timeout = len(ref) * 10
+
+        def wait_for_all():
+
+            results = [None] * len(ref)
+            done = [False] * len(ref)
+            remaining = ref[:]
+            ref_to_index = {r: i for i, r in enumerate(ref)}
+            start_time = time.time()
+
+            while remaining:
+                elapsed = time.time() - start_time
+                if elapsed >= timeout:
+                    break
+
+                remaining_timeout = timeout - elapsed
+                ready, remaining = ray.wait(
+                    remaining, num_returns=len(remaining), timeout=remaining_timeout
+                )
+
+                for ready_ref in ready:
+                    idx = ref_to_index[ready_ref]
+                    try:
+                        results[idx] = ray.get(ready_ref)
+                        done[idx] = True
+                    except Exception as e:
+                        results[idx] = e
+
+            for i, finish in enumerate(done):
+                if not finish:
+                    results[i] = TimeoutError(
+                        f"ray.wait timed out {timeout} for ray get at index {i}"
+                    )
+
+            for result in results:
+                if isinstance(result, Exception):
+                    raise result
+
+            return results
+
+        return await loop.run_in_executor(None, wait_for_all)
+    else:
+        return await loop.run_in_executor(None, partial(ray.get, timeout=timeout), ref)


### PR DESCRIPTION
## Why ?

Fix seveal container issues during testing swe-bench

## How ?

1. Make ContainerDeployment non-blocking. currently it won't become ruuning until all containers are alive. The means if we delete the deployment, the __del__ function is not called and no proper cleanup.
2. Add timeout in acquire/release/execute
3. Make ContainerClient return json with error key instead of throw exception.
4. add ray_get_async to wait for a list of futures

## Test plan

matrix check_health --app_name container
