### PR TITLE
feat: load HF datasets in inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,13 @@ matrix deploy_applications --applications "[{'model_name': 'meta-llama/Llama-4-M
 # download math-500 dataset
 python -m matrix.scripts.hf_dataset_to_jsonl HuggingFaceH4/MATH-500 test test.jsonl
 
-# query math-500
+# query math-500 from local jsonl
 matrix inference --app_name maverick-fp8 --input_jsonls test.jsonl --output_jsonl response.jsonl --batch_size=64 \
+  --system_prompt "Please reason step by step, and put your final answer within \boxed{}." --max_tokens 30000 --text_key problem --timeout_secs 1800
+
+# or query directly from the Hugging Face dataset
+matrix inference --app_name maverick-fp8 --input_hf_dataset HuggingFaceH4/MATH-500 --hf_dataset_split test \
+  --output_jsonl response.jsonl --batch_size=64 \
   --system_prompt "Please reason step by step, and put your final answer within \boxed{}." --max_tokens 30000 --text_key problem --timeout_secs 1800
 ```
 

--- a/matrix/app_server/app_api.py
+++ b/matrix/app_server/app_api.py
@@ -412,9 +412,12 @@ class AppApi:
         load_balance: bool = True,
         **kwargs,
     ):
-        """Run LLM inference."""
-
-        from matrix.client.query_llm import main as query
+        """Run LLM inference.
+        
+        The input can be provided either as JSONL files via ``input_jsonls`` or
+        fetched directly from a Hugging Face dataset using ``input_hf_dataset``
+        and ``hf_dataset_split``.
+        """
 
         metadata = self.get_app_metadata(app_name)
         assert self._cluster_info.hostname

--- a/matrix/app_server/app_api.py
+++ b/matrix/app_server/app_api.py
@@ -406,7 +406,9 @@ class AppApi:
         self,
         app_name: str,
         output_jsonl: str,
-        input_jsonls: str,
+        input_jsonls: str | None = None,
+        input_hf_dataset: str | None = None,
+        hf_dataset_split: str = "train",
         load_balance: bool = True,
         **kwargs,
     ):
@@ -448,6 +450,8 @@ class AppApi:
                     input_jsonls,
                     model=metadata["model_name"],
                     app_name=metadata["name"],
+                    input_hf_dataset=input_hf_dataset,
+                    hf_dataset_split=hf_dataset_split,
                     **kwargs,
                 )
             )
@@ -455,6 +459,7 @@ class AppApi:
             from matrix.client.execute_code import CodeExcutionClient
 
             client = CodeExcutionClient(get_one_endpoint)
+            assert input_jsonls is not None, "input_jsonls is required for code apps"
             return asyncio.run(
                 client.execute_code(
                     output_jsonl,
@@ -466,6 +471,7 @@ class AppApi:
             from matrix.client.process_vision_data import VisionClient
 
             vision_client = VisionClient(get_one_endpoint)
+            assert input_jsonls is not None, "input_jsonls is required for vision apps"
             return asyncio.run(
                 vision_client.inference(
                     output_jsonl,

--- a/matrix/app_server/app_api.py
+++ b/matrix/app_server/app_api.py
@@ -413,7 +413,7 @@ class AppApi:
         **kwargs,
     ):
         """Run LLM inference.
-        
+
         The input can be provided either as JSONL files via ``input_jsonls`` or
         fetched directly from a Hugging Face dataset using ``input_hf_dataset``
         and ``hf_dataset_split``.

--- a/matrix/cli.py
+++ b/matrix/cli.py
@@ -196,7 +196,15 @@ class Cli:
             yaml_config,
         )
 
-    def inference(self, app_name: str, output_jsonl: str, input_jsonls: str, **kwargs):
+    def inference(
+        self,
+        app_name: str,
+        output_jsonl: str,
+        input_jsonls: str | None = None,
+        input_hf_dataset: str | None = None,
+        hf_dataset_split: str = "train",
+        **kwargs,
+    ):
         """
         Run batch inference using a deployed application.
 
@@ -206,7 +214,9 @@ class Cli:
         Args:
             app_name (str): The name of the deployed application to use.
             output_jsonl (str): Path to save inference results in JSONL format.
-            input_jsonls (str): Path to input data in JSONL format.
+            input_jsonls (str | None): Path to input data in JSONL format.
+            input_hf_dataset (str | None): Hugging Face dataset name to load directly.
+            hf_dataset_split (str): Dataset split to load when using a Hugging Face dataset.
             **kwargs: Additional parameters for inference (e.g., temperature, max_tokens).
 
         Returns:
@@ -216,6 +226,8 @@ class Cli:
             app_name,
             output_jsonl,
             input_jsonls,
+            input_hf_dataset=input_hf_dataset,
+            hf_dataset_split=hf_dataset_split,
             **kwargs,
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dynamic = ["version", "description"]
 
 dependencies = [
   "psutil",
+  "datasets",
   "grpcio==1.70.0",
   "grpcio-tools==1.70.0",
   "fire",

--- a/tests/unit/query/test_load_from_hf_dataset.py
+++ b/tests/unit/query/test_load_from_hf_dataset.py
@@ -4,6 +4,9 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+import pytest
+
+pytest.importorskip("datasets")
 from datasets import Dataset
 
 

--- a/tests/unit/query/test_load_from_hf_dataset.py
+++ b/tests/unit/query/test_load_from_hf_dataset.py
@@ -1,0 +1,32 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+from datasets import Dataset
+
+
+def test_load_from_hf_dataset(monkeypatch):
+    from matrix.client import query_llm
+
+    dataset = Dataset.from_dict({"problem": ["1+1", "2+2"]})
+
+    def mock_load_dataset(*args, **kwargs):
+        return dataset
+
+    monkeypatch.setattr("datasets.load_dataset", mock_load_dataset)
+
+    lines = query_llm.load_from_hf_dataset(
+        "dummy",
+        "train",
+        text_key="problem",
+        messages_key="request.messages",
+        system_prompt="sys",
+    )
+
+    assert len(lines) == 2
+    assert lines[0]["messages"][0]["role"] == "system"
+    assert lines[0]["messages"][0]["content"] == "sys"
+    assert lines[0]["messages"][1]["content"] == "1+1"
+    assert lines[0]["metadata"]["index"] == 0


### PR DESCRIPTION
Changes:
- Implemented direct Hugging Face dataset ingestion by introducing a new `load_from_hf_dataset` helper and extending the inference entry point with optional `input_hf_dataset` and `hf_dataset_split` parameters, allowing users to skip manual JSONL conversion.
- Extended the CLI’s inference method to accept `input_hf_dataset` and `hf_dataset_split` parameters, routing them to the application API.

Why?
- Closes #46 