### PR TITLE
add use_v1_engine as BaseDeployment attribute

### DIFF
--- a/matrix/app_server/llm/ray_serve_vllm.py
+++ b/matrix/app_server/llm/ray_serve_vllm.py
@@ -113,6 +113,7 @@ if original_post_init is not None:
 
 class BaseDeployment:
     lora_modules: Optional[List[LoRAModulePath]] = None
+    use_v1_engine: Optional[bool] = None
 
     def __init__(
         self,


### PR DESCRIPTION
## Why ?

similar to https://github.com/facebookresearch/matrix/pull/16
enable use_v1_engine as a param that can be passed from command


## Test plan

python -m matrix deploy_applications  --applications '[{"name": "Qwen3-32B_grpc", "model_name": "/checkpoint/data/shared/Qwen3-32B", "min_replica": 1, "model_size": "Qwen3-32B", "use_grpc": "true", "use_v1_engine": "true"}]'
