### PR TITLE
Support fastgen as llm backend

### DIFF
--- a/matrix/app_server/app_api.py
+++ b/matrix/app_server/app_api.py
@@ -438,6 +438,7 @@ class AppApi:
         if app_type in [
             "llm",
             "sglang_llm",
+            "fastgen",
             "openai",
             "metagen",
             "sagemaker",

--- a/matrix/app_server/llm/ray_serve_fastgen.py
+++ b/matrix/app_server/llm/ray_serve_fastgen.py
@@ -1,0 +1,330 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import asyncio
+import logging
+import os
+import subprocess as sp
+import sys
+import tempfile
+from dataclasses import dataclass
+from inspect import Parameter, signature
+from multiprocessing import Pipe, Process
+from multiprocessing.connection import Client, Connection, Listener
+from queue import Queue
+from threading import Thread
+from typing import Dict, List, Optional, Union
+from uuid import uuid4
+
+import torch
+from fastapi import FastAPI
+from fastgen.generate import Fastgen, GenArgs, Packet
+from fastgen.utils.loading import HfLoader
+from fastgen.utils.tokenizer import BaseTokenizer
+from ray import serve
+from torch.distributed.device_mesh import DeviceMesh, init_device_mesh
+
+logger = logging.getLogger("ray.serve")
+
+app = FastAPI()
+
+
+@dataclass
+class Request:
+    messages: list[dict[str, str]]
+    temperature: float = 0.8
+    top_p: float = 0.95  # ignored
+    max_tokens: int = 0
+    min_tokens: int = 0  # ignored
+    model: Optional[str] = None  # ignored
+    n: int = 1
+    stop: Optional[str] = None  # ignored
+    seed: Optional[int] = None  # ignored
+    logprobs: Optional[bool] = None  # ignored
+    top_logprobs: Optional[int] = None  # ignored
+    extra_headers: Optional[dict] = None  # ignored
+    extra_body: Optional[dict] = None  # ignored
+
+
+def worker_enqueuer(c: Connection, q: Queue) -> None:
+    "Enqueuer thread."
+    while True:
+        msg, payload = c.recv()
+        if msg == "quit":
+            q.put(None)
+            return
+
+        if msg == "gen":
+            rid, req, toks = payload
+            if req.max_tokens <= 0:
+                max_gen: Optional[int] = None
+            else:
+                max_gen = req.max_tokens
+            for _ in range(req.n):
+                q.put(
+                    Packet(
+                        thread_id=rid,
+                        temperature=req.temperature,
+                        max_gen=max_gen,
+                        tokens=toks,
+                    )
+                )
+
+
+def worker_main(
+    args: argparse.Namespace,
+    rdv_dir: str,
+    rank: int,
+    c: Connection,
+) -> None:
+    pid = os.getpid()
+    logger.warning(f"Worker {rank} starting with PID {pid}")
+    world_size = args.tensor_parallel_size
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+    if world_size == 1:
+        mesh: Optional[DeviceMesh] = None
+    else:
+        torch.distributed.init_process_group(
+            backend="nccl",
+            rank=rank,
+            world_size=args.tensor_parallel_size,
+            init_method=f"file://{rdv_dir}/rdv",
+        )
+        mesh = init_device_mesh("cuda", (world_size,))
+
+    torch.manual_seed(777)
+    torch.set_default_device(device)
+
+    loader = HfLoader(args.model)
+    fg = Fastgen.build(
+        loader=loader,
+        gen_args=GenArgs(),
+        tp_mesh=mesh,
+        device=device,
+    )
+    c.send("ready")
+
+    q: Queue = Queue()
+
+    enqueuer_thread = Thread(target=worker_enqueuer, args=(c, q), daemon=True)
+    enqueuer_thread.start()
+
+    for pkt in fg.generate(q):
+        if rank == 0:
+            c.send((pkt.thread_id, pkt.tokens))
+
+    enqueuer_thread.join()
+    fg.destroy()
+    if mesh is not None:
+        torch.distributed.destroy_process_group()
+
+
+@serve.deployment(
+    autoscaling_config={
+        "min_replicas": 1,
+        "max_replicas": 8,
+        "target_ongoing_requests": 64,
+    },
+    max_ongoing_requests=64,  # make this large so that multi-turn can route to the same replica
+)
+@serve.ingress(app)
+class FastgenDeployment:
+
+    def __init__(
+        self,
+        engine_args: argparse.Namespace,
+    ):
+        logger.warning(f"Starting with engine args: {engine_args} and env: {os.environ}")
+        self.engine_args = engine_args
+        self.workers: list[tuple[sp.Popen, Connection]] = []
+        self.handles: dict[str, Queue[list[int]]] = {}
+        self.running: bool = True
+        self.tokenizer: BaseTokenizer = None  # type: ignore[assignment]
+        self.setup(engine_args)
+
+    def receiver(self, loop: asyncio.AbstractEventLoop):
+        """Receiver thread"""
+        while self.running:
+            rid, tokens = self.workers[0][1].recv()
+
+            # Find the asyncio.Queue handle
+            hnd = self.handles.get(rid)
+            if hnd is None:
+                logger.warning(f"Got completion for unknown handle {rid}")
+                continue
+
+            # Schedule async put into the queue from this thread
+            asyncio.run_coroutine_threadsafe(hnd.put(tokens), loop)
+
+    def setup(self, args):
+        self.gpu_ids = os.environ["CUDA_VISIBLE_DEVICES"].split(",")
+        assert len(self.gpu_ids) == args.tensor_parallel_size
+
+        loader = HfLoader(args.model)
+        # global tokenizer
+        self.tokenizer = loader.load_tokenizer()
+
+        # spawn worker processes
+        with tempfile.TemporaryDirectory() as rdv_dir:
+            for rank in range(args.tensor_parallel_size):
+                parent_conn, child_conn = Pipe()  # create two ends of the connection
+                os.environ["ENABLE_INTRA_NODE_COMM"] = "1"
+                os.environ["TORCH_NCCL_AVOID_RECORD_STREAMS"] = "1"
+                os.environ["CUDA_VISIBLE_DEVICES"] = "0" # self.gpu_ids[rank]
+
+                p = Process(
+                    target=worker_main,
+                    args=(
+                        args,
+                        rdv_dir,
+                        rank,
+                        child_conn,
+                    ),
+                )
+                p.start()
+                self.workers.append((p, parent_conn))
+
+            # wait for workers to be ready
+            for _, c in self.workers:
+                logger.info("Waiting for worker to be ready")
+                _ = c.recv()
+
+        loop = asyncio.get_event_loop()
+        receiver_thread = Thread(target=self.receiver, args=(loop,), daemon=True)
+        receiver_thread.start()
+
+    @app.post("/v1/chat/completions")
+    async def create_chat_completion(self, request: Request):
+        """OpenAI-compatible HTTP endpoint."""
+        logger.info(f"Request: {request}")
+
+        rq = request  # Request(**completion_request)
+        rid = uuid4().hex
+        prompt_tokens = self.tokenizer.encode_dialog(rq.messages)
+        hnd = asyncio.Queue()
+        self.handles[rid] = hnd
+        for _, c in self.workers:
+            c.send(("gen", (rid, rq, prompt_tokens)))
+        rsp = {
+            "id": rid,
+            "choices": [],
+            "created": 0,
+            "model": rq.model,
+            "object": "chat.completion",
+            "usage": {
+                "completion_tokens": 0,
+                "prompt_tokens": len(prompt_tokens),
+                "total_tokens": len(prompt_tokens),
+            },
+        }
+        for ix in range(rq.n):
+            tokens = await hnd.get()
+            rsp["usage"]["completion_tokens"] += len(tokens)
+            rsp["usage"]["total_tokens"] += len(tokens)
+            if tokens[-1] in self.tokenizer.stop_tokens:
+                tokens = tokens[:-1]
+                stopped = True
+            else:
+                stopped = False
+            rsp["choices"].append(
+                {
+                    "index": ix,
+                    "message": {
+                        "role": "assistant",
+                        "content": self.tokenizer.decode(tokens),
+                    },
+                    "finish_reason": "stop" if stopped else "length",
+                }
+            )
+        del self.handles[rid]
+        return rsp
+
+    def __del__(self):
+        self.running = False
+
+
+def parse_engine_args(cli_args: Dict[str, str]):
+    """Parses engine args based on CLI inputs.
+    """
+    parser = argparse.ArgumentParser(description="Example with type annotations")
+
+    parser.add_argument(
+        "--model",
+        type=str,
+        required=True,
+        help="model name",
+    )
+    parser.add_argument(
+        "--tensor-parallel-size",
+        type=int,
+        default=1,
+        help="Size of tensor parallelism (int)",
+    )
+    parser.add_argument(
+        "--pipeline-parallel-size",
+        type=int,
+        default=1,
+        help="Size of pipeline parallelism (int)",
+    )
+    parser.add_argument(
+        "--enable-prefix-caching",
+        action="store_true",
+        help="Enable prefix caching (bool)",
+    )
+    parser.add_argument(
+        "--max-ongoing-requests",
+        type=int,
+        default=100,
+        help="Maximum number of ongoing requests (int)",
+    )
+    parser.add_argument(
+        "--max-model-len",
+        type=int,
+        default=32768,
+        help="Maximum model length (int)",
+    )
+    parser.add_argument(
+        "--gpu-memory-utilization",
+        type=float,
+        default=0.8,
+        help="GPU memory utilization (float)",
+    )
+
+    arg_strings = []
+    for key, value in cli_args.items():
+        if value is None:
+            arg_strings.extend([f"--{key}"])
+        else:
+            arg_strings.extend([f"--{key}", str(value)])
+    logger.info(arg_strings)
+    parsed_args = parser.parse_args(args=arg_strings)
+    return parsed_args
+
+
+def build_app(cli_args: Dict[str, str]) -> serve.Application:
+    """Builds the Serve app based on CLI arguments.
+    """  # noqa: E501
+    accelerator = "GPU"
+    engine_args = parse_engine_args(cli_args)
+
+    tp = engine_args.tensor_parallel_size
+    pp = engine_args.pipeline_parallel_size
+    logger.info(f"Tensor parallelism = {tp}, Pipeline parallelism = {pp}")
+    pg_resources = []
+    pg_resources.append({"CPU": 1})  # for the deployment replica
+    for i in range(tp * pp):
+        pg_resources.append({"CPU": 4, accelerator: 1})  # for the actors
+
+    # We use the "STRICT_PACK" strategy below to ensure all actors are placed on
+    # the same Ray node.
+    return FastgenDeployment.options(  # type: ignore[union-attr]
+        placement_group_bundles=pg_resources,
+        placement_group_strategy="STRICT_PACK" if pp == 1 else "PACK",
+    ).bind(
+        engine_args,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,6 +166,22 @@ classifiers=[
       "tenacity",
       "perception_models @ git+https://github.com/facebookresearch/perception_models.git"
   ]
+  fastgen = [
+      "submitit>=1.5.2",
+      "transformers>=4.45.2",
+      "torch>=2.7.1",
+      "ray[serve]>=2.48.0",
+      "boto3",
+      "google-genai>=1.13.0",
+      "datasketch",
+      "s3fs",
+      "datasets",
+      "iopath",
+      "jsonlines",
+      "flash-attn==2.7.3",
+      "fastgen @ git+https://github.com/dongwang218/fastgen.git"
+  ]
+
 [project.scripts]
 matrix="matrix.cli:main"
 


### PR DESCRIPTION
## Why ?

fastgen is an efficient llm inference engine https://github.com/facebookresearch/fastgen

## How ?

use ray serve and placement_group to acquire resources
adapt fastgen's serve into Deployment endpoint and WorkerWrapper

## Test plan

* 8B test
```
matrix deploy_applications --action add --applications  "[{'model_name': '/datasets/pretrained-llms/Llama-3.1-8B-Instruct', 'use_grpc': 'false', 'min_replica': 1, 'model_size': '8B', 'name': '8B', 'app_type': 'fastgen', 'tensor-parallel-size': 1}]"

matrix check_health --app_name 8B
```
* 70B test
```
matrix deploy_applications --action replace --applications "[{'model_name': '/datasets/pretrained-llms/Llama-3.3-70B-Instruct', 'use_grpc': 'false', 'min_replica': 4, 'model_size': '70B', 'name': '70B', 'app_type': 'fastgen', 'tensor-parallel-size': 8}]"

matrix inference --app_name 70B --input_jsonls test.jsonl --output_jsonl fasgen_70b_response.jsonl --batch_size=128 --system_prompt "Reasoning: high. Please reason step by step, and put your final answer within \boxed{}." --max_tokens 30000 --text_key problem --timeout_secs 3600
 499/500 [03:44<00:14
████| 500/500 [18:48<00:00
{'num_samples': 500, 'num_scores': 500, 'timeout_samples': 0, 'empty_samples': 0, 'acc': 74.2}
```