### PR TITLE
remove duplication and add default to `get_nested_value`

### DIFF
--- a/matrix/app_server/vision/optical_flow.py
+++ b/matrix/app_server/vision/optical_flow.py
@@ -20,10 +20,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 from torch.utils.data import DataLoader, Dataset
 
-from matrix.app_server.vision.utils import (
-    SamplingMode,
-    TorchCodecVideoDataset,
-)
+from matrix.app_server.vision.utils import SamplingMode, TorchCodecVideoDataset
 
 logger = logging.getLogger("ray.serve")
 logging.getLogger("httpx").setLevel(logging.WARNING)

--- a/matrix/client/endpoint_cache.py
+++ b/matrix/client/endpoint_cache.py
@@ -11,9 +11,7 @@ import time
 
 from matrix.common.cluster_info import ClusterInfo, get_head_http_host
 from matrix.utils.http import fetch_url
-from matrix.utils.ray import (
-    get_ray_dashboard_address,
-)
+from matrix.utils.ray import get_ray_dashboard_address
 
 logger = logging.getLogger("endpoint_cache")
 

--- a/matrix/cluster/ray_head_job.py
+++ b/matrix/cluster/ray_head_job.py
@@ -20,10 +20,7 @@ from pathlib import Path
 import ray
 
 from matrix.common.cluster_info import ClusterInfo
-from matrix.utils.os import (
-    find_free_ports,
-    read_stdout_lines,
-)
+from matrix.utils.os import find_free_ports, read_stdout_lines
 
 
 class RayHeadJob:

--- a/matrix/data_pipeline/clustering/sample.py
+++ b/matrix/data_pipeline/clustering/sample.py
@@ -24,12 +24,7 @@ from sklearn.metrics import pairwise_distances
 from .fit import generate_embeddings, generate_ump_embeddings
 
 # Import shared utilities
-from .utils import (
-    get_outputs_path,
-    inner_join,
-    logger,
-    summarize_clustering_stats,
-)
+from .utils import get_outputs_path, inner_join, logger, summarize_clustering_stats
 
 
 @ray.remote

--- a/matrix/data_pipeline/clustering/utils.py
+++ b/matrix/data_pipeline/clustering/utils.py
@@ -19,7 +19,7 @@ import ray
 import torch
 from sentence_transformers import SentenceTransformer
 
-from matrix.utils.basics import get_user_message_from_llama3_prompt
+from matrix.utils.basics import get_nested_value, get_user_message_from_llama3_prompt
 
 # Basic Logging Setup
 logging.basicConfig(
@@ -97,18 +97,6 @@ def get_outputs_path(
 
 def xxhash128(text: str) -> str:
     return xxhash.xxh3_128_hexdigest(text)
-
-
-def get_nested_value(d, path: str):
-    """Access nested dict/list using a dotted string path like 'a.b[0].c'."""
-    tokens = re.findall(r"[^[\].]+|\[\d+\]", path)
-    for token in tokens:
-        if token.startswith("[") and token.endswith("]"):
-            index = int(token[1:-1])
-            d = d[index]
-        else:
-            d = d[token]
-    return d
 
 
 def is_valid_parquet(path: str) -> bool:

--- a/matrix/job/job_manager.py
+++ b/matrix/job/job_manager.py
@@ -23,16 +23,8 @@ from typing import cast
 
 import ray
 
-from matrix.job.job_utils import (
-    JobAlreadyExist,
-    JobNotFound,
-    generate_task_id,
-)
-from matrix.utils.ray import (
-    status_is_failure,
-    status_is_pending,
-    status_is_success,
-)
+from matrix.job.job_utils import JobAlreadyExist, JobNotFound, generate_task_id
+from matrix.utils.ray import status_is_failure, status_is_pending, status_is_success
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)

--- a/matrix/utils/basics.py
+++ b/matrix/utils/basics.py
@@ -110,7 +110,7 @@ def get_nested_value(d, path: str, default: Any | None = None) -> Any:
     Returns:
         The resolved value or ``default`` if any part of the path is missing.
     """
-    
+
     tokens = re.findall(r"[^\[\].]+|\[\d+\]", path)
     try:
         for token in tokens:

--- a/matrix/utils/basics.py
+++ b/matrix/utils/basics.py
@@ -92,9 +92,26 @@ def str_to_callable(dotted_path: str):
     return obj
 
 
-def get_nested_value(d, path: str):
-    """Access nested dict/list using a dotted string path like 'a.b[0].c'."""
-    tokens = re.findall(r"[^[\].]+|\[\d+\]", path)
+def get_nested_value(d, path: str, default: Any | None = None) -> Any:
+    """Access nested ``dict``/``list`` using a dotted string path.
+
+    When the path cannot be fully resolved, ``default`` is returned.
+    Example::
+
+        data = {"a": {"b": [1]}}
+        get_nested_value(data, "a.b[0]")       # -> 1
+        get_nested_value(data, "a.c", "miss")  # -> "miss"
+
+    Args:
+        d: Root dictionary/list to traverse.
+        path: Dotted path string such as ``"a.b[0].c"``.
+        default: Value returned when the path does not exist.
+
+    Returns:
+        The resolved value or ``default`` if any part of the path is missing.
+    """
+    
+    tokens = re.findall(r"[^\[\].]+|\[\d+\]", path)
     try:
         for token in tokens:
             if token.startswith("[") and token.endswith("]"):
@@ -104,4 +121,4 @@ def get_nested_value(d, path: str):
                 d = d[token]
         return d
     except (KeyError, IndexError, TypeError):
-        return None
+        return default

--- a/matrix/utils/basics.py
+++ b/matrix/utils/basics.py
@@ -105,7 +105,7 @@ def get_nested_value(d, path: str, default: Any | None = None) -> Any:
     Args:
         d: Root dictionary/list to traverse.
         path: Dotted path string such as ``"a.b[0].c"``.
-        default: Value returned when the path does not exist.
+        default (Optional): Value returned when the path does not exist.
 
     Returns:
         The resolved value or ``default`` if any part of the path is missing.

--- a/tests/integration/app_server/test_deploy_hello.py
+++ b/tests/integration/app_server/test_deploy_hello.py
@@ -13,10 +13,7 @@ import pytest
 import ray
 
 from matrix.cli import Cli
-from matrix.utils.ray import (
-    status_is_pending,
-    status_is_success,
-)
+from matrix.utils.ray import status_is_pending, status_is_success
 
 
 @pytest.fixture(scope="module")

--- a/tests/unit/utils/test_basics.py
+++ b/tests/unit/utils/test_basics.py
@@ -105,6 +105,7 @@ def test_get_nested_value():
     assert get_nested_value(data, "x[0]") == 10
     assert get_nested_value(data, "a.b[2].c") is None
     assert get_nested_value(data, "a.b.c") is None
+    assert get_nested_value(data, "missing.path", default="fallback") == "fallback"
 
 
 def test_str_to_callable_success():


### PR DESCRIPTION
Changes:
- Added an optional default argument to `get_nested_value` enabling safe traversal of nested dictionaries or lists when keys or indices may be absent.
- Replaced the local nested-value lookup in the clustering utilities with the shared helper, removing duplication.