### PR TITLE
[EZ] fix response text

### DIFF
--- a/matrix/client/query_llm.py
+++ b/matrix/client/query_llm.py
@@ -301,7 +301,7 @@ async def make_request(
                             },
                         }
                         if response.choices[0].message.content:
-                            result["response"]["text"] = ([response.choices[i].message.content for i in range(n)],)  # type: ignore[attr-defined]
+                            result["response"]["text"] = [response.choices[i].message.content for i in range(n)]  # type: ignore[attr-defined]
                         if response.choices[0].message.tool_calls:
                             result["response"]["tool_calls"] = [
                                 [
@@ -484,7 +484,7 @@ async def make_request(
                             },
                         }
                         if response.choices[0].message.content:
-                            result["response"]["text"] = ([response.choices[i].message.content for i in range(n)],)  # type: ignore[attr-defined]
+                            result["response"]["text"] = [response.choices[i].message.content for i in range(n)]  # type: ignore[attr-defined]
                         if response.choices[0].message.tool_calls:
                             result["response"]["tool_calls"] = [
                                 [


### PR DESCRIPTION
## Why ?

extra parenthesis was added in previous PR, remove

## Test plan

query a model and read `response['response']['text'][0]`, output text instead of a list
