### PR TITLE
fix: join output thread before collecting stdout, refactor `lock_file` and expanded tests for `ray` and `os`

### DIFF
--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -38,6 +38,7 @@ async def test_fetch_url(unused_tcp_port):
         assert status == 200
         assert content == "hello"
     finally:
+        await site.stop()
         await runner.cleanup()
 
 
@@ -75,6 +76,7 @@ async def test_post_url(unused_tcp_port):
         assert status == 200
         assert json.loads(content) == {"foo": "bar"}
     finally:
+        await site.stop()
         await runner.cleanup()
 
 
@@ -114,6 +116,7 @@ def test_fetch_url_sync(unused_tcp_port):
     finally:
         server.shutdown()
         thread.join()
+        server.server_close()
 
     with patch("requests.get") as mock_get:
         mock_get.side_effect = Exception("boom")

--- a/tests/unit/utils/test_ray.py
+++ b/tests/unit/utils/test_ray.py
@@ -4,6 +4,11 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+import json
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
 import pytest
 
 from matrix.common.cluster_info import ClusterInfo
@@ -29,3 +34,113 @@ def test_status_helpers():
         ray_utils.status_is_pending,
     ]:
         assert not fn("UNKNOWN")
+
+
+def test_get_matrix_actors(monkeypatch):
+    info = ClusterInfo(hostname="h", client_server_port=1, dashboard_port=2)
+    actors = [
+        {"name": "a1", "ray_namespace": "matrix"},
+        {"name": "b1", "ray_namespace": "matrix"},
+    ]
+    result_ok = SimpleNamespace(returncode=0, stdout=json.dumps(actors))
+    with patch("subprocess.run", return_value=result_ok):
+        assert ray_utils.get_matrix_actors(info, prefix="a") == [
+            {"name": "a1", "ray_namespace": "matrix"}
+        ]
+
+    result_bad_json = SimpleNamespace(returncode=0, stdout="not json")
+    with patch("subprocess.run", return_value=result_bad_json):
+        assert ray_utils.get_matrix_actors(info) == []
+
+    result_error = SimpleNamespace(returncode=1, stderr="boom", stdout="")
+    with patch("subprocess.run", return_value=result_error):
+        assert ray_utils.get_matrix_actors(info) == []
+
+
+def test_get_serve_applications(monkeypatch):
+    payload = [{"name": "app"}]
+    monkeypatch.setattr(
+        ray_utils,
+        "fetch_url_sync",
+        lambda url, headers=None: (200, json.dumps(payload)),
+    )
+    assert ray_utils.get_serve_applications("http://ray") == payload
+
+    monkeypatch.setattr(
+        ray_utils, "fetch_url_sync", lambda url, headers=None: (500, "error")
+    )
+    assert ray_utils.get_serve_applications("http://ray") == []
+
+
+@pytest.mark.asyncio
+async def test_ray_get_async_single():
+    fake_ray = SimpleNamespace(get=lambda ref, timeout=None: ref * 2)
+    with patch.dict(sys.modules, {"ray": fake_ray}):
+        assert await ray_utils.ray_get_async(3) == 6
+
+
+@pytest.mark.asyncio
+async def test_ray_get_async_list():
+    def fake_wait(refs, num_returns, timeout):
+        return refs, []
+
+    fake_ray = SimpleNamespace(wait=fake_wait, get=lambda ref: ref * 2)
+    with patch.dict(sys.modules, {"ray": fake_ray}):
+        assert await ray_utils.ray_get_async([1, 2]) == [2, 4]
+
+
+@pytest.mark.asyncio
+async def test_ray_get_async_timeout():
+    def fake_wait(refs, num_returns, timeout):
+        return [], refs
+
+    fake_ray = SimpleNamespace(wait=fake_wait, get=lambda ref, timeout=None: ref)
+    with patch.dict(sys.modules, {"ray": fake_ray}):
+        with pytest.raises(TimeoutError):
+            await ray_utils.ray_get_async([1, 2], timeout=0)
+
+
+def test_kill_matrix_actors(monkeypatch):
+    info = ClusterInfo(hostname="h", client_server_port=1, dashboard_port=2)
+
+    actor_seq = iter(
+        [
+            [
+                {"name": "a1", "ray_namespace": "matrix"},
+                {"name": "system.actor", "ray_namespace": "matrix"},
+            ],
+            [],
+        ]
+    )
+
+    monkeypatch.setattr(
+        ray_utils, "get_matrix_actors", lambda *a, **kw: next(actor_seq)
+    )
+
+    calls: list[str] = []
+
+    class Handle:
+        def __init__(self, name):
+            self.name = name
+
+            class K:
+                def __init__(self, n):
+                    self.n = n
+
+                def remote(self):
+                    calls.append(f"kill.remote:{self.n}")
+
+            self.kill = K(name)
+
+    def fake_get_actor(name, ns):
+        return Handle(name)
+
+    def fake_kill(handle):
+        calls.append(f"ray.kill:{handle.name}")
+
+    fake_ray = SimpleNamespace(get_actor=fake_get_actor, kill=fake_kill)
+    with patch.dict(sys.modules, {"ray": fake_ray}):
+        deleted = ray_utils.kill_matrix_actors(info, prefix="a")
+
+    assert deleted == ["a1"]
+    assert calls == ["kill.remote:a1", "ray.kill:a1"]


### PR DESCRIPTION
Changes:
- Ensured `run_and_stream` waits for its output thread and filters skipped log lines during final flush, guaranteeing complete stdout capture.
- Implemented non-blocking file locking that retries until a timeout is reached, raising a clear TimeoutError when contention persists.
- Ensured HTTP utility tests stop aiohttp sites and shut down the local HTTP server cleanly, preventing unclosed loop/socket warnings.
- Added tests for lock acquisition under contention and for constructing S3 download commands with and without exclusion patterns.