### PR TITLE
[gpt-oss] function call

### DIFF
--- a/matrix/app_server/llm/llm_config.py
+++ b/matrix/app_server/llm/llm_config.py
@@ -190,7 +190,7 @@ llm_model_default_parameters = {
         "tensor-parallel-size": 2,
         "pipeline-parallel-size": 1,
         "enable-prefix-caching": True,
-        "max_ongoing_requests": 150,
+        "max_ongoing_requests": 100,
         "max-model-len": 32768,
         "gpu-memory-utilization": 0.8,
         "tool-call-parser": "hermes",
@@ -214,6 +214,7 @@ llm_model_default_parameters = {
         "gpu-memory-utilization": 0.85,
         "max_ongoing_requests": 64,
         "use_v1_engine": "true",
+        "tool-call-parser": "openai",
     },
     # need to install vllm_0101_gptoss
     "openai/gpt-oss-120b": {
@@ -224,6 +225,7 @@ llm_model_default_parameters = {
         "gpu-memory-utilization": 0.85,
         "max_ongoing_requests": 64,
         "use_v1_engine": "true",
+        "tool-call-parser": "openai",
     },
     "google/gemma-3-27b-it": {
         "name": "gemma-3-27b-it",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,13 +132,13 @@ classifiers=[
       "iopath",
       "jsonlines",
   ]
-  # For gpt-oss model with PP=1
-  vllm_0101 = [
+  # For gpt-oss model with PP=1, and gpt-oss tool use
+  vllm_0102 = [
       # install using https://docs.vllm.ai/projects/recipes/en/latest/OpenAI/GPT-OSS.html
       "submitit>=1.5.2",
       "transformers>=4.45.2",
       "torch>=2.7.1",
-      "vllm==0.10.1",
+      "vllm==0.10.2",
       "ray[serve]>=2.48.0",
       "boto3",
       "google-genai>=1.13.0",


### PR DESCRIPTION
## Why ?

add tool-call-parser for gpt-oss model. vllm >= 0.10.2

bump vllm to 0.10.2. tested with Llama-405B and Qwen3-235B.

## Test plan

`python -m matrix deploy_applications --action add --applications '[{"model_name": "openai/gpt-oss-120b", "model_size": "gpt-oss-120b", "name": "gpt120b", "min_replica": 1, "enable_tools": "true"}]'`

```
{'request': {'messages': [{'role': 'user',
    'content': "What's the weather like in San Francisco?"}],
  'metadata': {'request_timestamp': 1758062988.7081532}},
 'response': {'finish_reason': ['tool_calls'],
  'response_timestamp': 1758062990.4790025,
  'text': ['The current weather in San\u202fFrancisco, CA is **57\u202f°F** with light rain and a gentle breeze. The humidity is around 78\u202f% and the forecast calls for a chance of showers later this afternoon.'],
  'tool_calls': [[{'name': 'get_weather',
     'arguments': '{\n  "location": "San Francisco, CA",\n  "unit": "fahrenheit"\n}',
     'id': '7785d31c-7b79-4642-8e84-edb16b446913'}]],
  'usage': {'prompt_tokens': 152,
   'completion_tokens': 146,
   'total_tokens': 298}}}
```
