### PR TITLE
overwrite grafana db path

### DIFF
--- a/matrix/__init__.py
+++ b/matrix/__init__.py
@@ -11,7 +11,7 @@ matrix.
 Multi-Agent daTa geneRation Infra and eXperimentation framework.
 """
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 __author__ = "FAIR"
 __credits__ = "FAIR - Meta"
 __description__ = "Multi-Agent daTa geneRation Infra and eXperimentation framework."

--- a/matrix/cli.py
+++ b/matrix/cli.py
@@ -386,10 +386,13 @@ class Cli:
                             "content": prompt,
                         },
                     ],
-                    "tools": tools,
-                    "tool_choice": tool_choice,
                     "temperature": 0.7,
                 }
+                if tools:
+                    data_payload |= {
+                        "tools": tools,
+                        "tool_choice": tool_choice,
+                    }
                 if use_curl and not metadata["use_grpc"]:
                     url = f"{metadata['endpoints']['head']}/chat/completions"
                     data_json = json.dumps(data_payload)

--- a/matrix/cli.py
+++ b/matrix/cli.py
@@ -388,7 +388,7 @@ class Cli:
                     ],
                     "temperature": 0.7,
                 }
-                if tools:
+                if use_tools:
                     data_payload |= {
                         "tools": tools,
                         "tool_choice": tool_choice,

--- a/matrix/client/query_llm.py
+++ b/matrix/client/query_llm.py
@@ -227,7 +227,7 @@ async def make_request(
     multiplexed_model_id: str = "",
     timeout_secs: int = 600,
     tools: tp.Iterable[ChatCompletionToolUnionParam] | NotGiven = NOT_GIVEN,
-    tool_choice: ChatCompletionToolChoiceOptionParam = None,
+    tool_choice: ChatCompletionToolChoiceOptionParam | NotGiven = NOT_GIVEN,
     prompt_logprobs: tp.Optional[int] = None,
     endpoint_cache: tp.Optional[EndpointCache] = None,
     top_k: int = -1,
@@ -485,7 +485,9 @@ async def make_request(
                             messages=messages,
                             top_p=top_p,
                             temperature=temperature,
-                            tool_choice=tool_choice,
+                            tool_choice=(
+                                tool_choice if tool_choice is not NOT_GIVEN else None
+                            ),
                             tools=tools if tools is not NOT_GIVEN else None,
                             n=n,
                             seed=seed,

--- a/matrix/cluster/ray_cluster.py
+++ b/matrix/cluster/ray_cluster.py
@@ -32,6 +32,7 @@ from matrix.utils.ray import ACTOR_NAME_SPACE, get_ray_head_node, init_ray_if_ne
 _SLURM_KEY_ALIASES: dict[str, str] = {
     "slurm_account": "account",
     "slurm_qos": "qos",
+    "slurm_partition": "partition",
 }
 
 
@@ -329,6 +330,12 @@ class RayCluster:
             with (
                 s_executor.batch()
             ):  # TODO set slurm array max parallelism here, because we really want all jobs to be scheduled at the same time
+                logical_resources = {
+                    f"{key}-{value}": 1
+                    for key, value in requirements.items()
+                    if key in _SLURM_KEY_ALIASES.values()
+                }
+
                 for i in range(add_workers):
                     jobs.append(
                         s_executor.submit(
@@ -336,6 +343,7 @@ class RayCluster:
                                 cluster_info,
                                 worker_wait_timeout_seconds,
                                 start_wait_time_seconds,
+                                logical_resources,
                             )
                         )
                     )

--- a/matrix/cluster/ray_dashboard_job.py
+++ b/matrix/cluster/ray_dashboard_job.py
@@ -205,6 +205,9 @@ class RayDashboardJob:
         )
 
         head_env["GF_SERVER_HTTP_PORT"] = str(port)
+        head_env["GF_DATABASE_PATH"] = (
+            f"{temp_dir}/session_latest/metrics/grafana/grafana.db"
+        )
         conda_prefix = os.environ.get("CONDA_PREFIX")
         with (
             open(f"{temp_dir}/session_latest/logs/grafana.out", "w") as stdout_file,

--- a/matrix/cluster/ray_worker_job.py
+++ b/matrix/cluster/ray_worker_job.py
@@ -25,7 +25,7 @@ class _RayWorkerConfiguration:
     worker_wait_timeout_seconds: int = 60
     start_wait_time_seconds: int = 60
     environment: Dict[str, str] = field(default_factory=dict)
-    logical_resources: Dict[str, Any] = field(default_factory=dict)
+    logical_resources: str = "{}"
 
     def _determine_resource_allocation(self) -> tuple:
         """Dynamically determine CPU and GPU resources based on execution environment."""
@@ -84,7 +84,7 @@ class _RayWorkerJobExecutor:
         worker_env: Dict[str, str],
         num_cpus: int,
         num_gpus: int,
-        logical_resources: Dict[str, str],
+        logical_resources: str,
     ) -> None:
         """
         Start Ray worker with specified environment and resources.


### PR DESCRIPTION
## Why ?

by default, grafana is using the db from homepath

## How ?

overwrite to use a new db per cluster

## Test plan

matrix start_cluster --enable_grafana