### PR TITLE
calculating resources with clusterscope

### DIFF
--- a/matrix/cluster/ray_cluster.py
+++ b/matrix/cluster/ray_cluster.py
@@ -248,7 +248,7 @@ class RayCluster:
             if executor == "slurm":
                 # clusterscope assigns the proportionate amount of resources based on gpus/cpus being requested.
                 resources = clusterscope.job_gen_task_slurm(
-                    partition=requirements["partition"],
+                    partition=str(requirements["partition"]),
                     cpus_per_task=default_params["cpus_per_task"],
                 )
                 default_params["mem_gb"] = resources["mem_gb"]
@@ -323,9 +323,9 @@ class RayCluster:
             if executor == "slurm":
                 # clusterscope assigns the proportionate amount of resources based on gpus/cpus being requested.
                 resources = clusterscope.job_gen_task_slurm(
-                    partition=requirements["partition"],
+                    partition=str(requirements["partition"]),
                     gpus_per_task=default_params["gpus_per_node"],
-                    ntasks_per_node=default_params["ntasks_per_node"],
+                    tasks_per_node=default_params["ntasks_per_node"],
                 )
                 default_params["cpus_per_task"] = resources["cpus_per_task"]
                 default_params["mem_gb"] = resources["mem_gb"]

--- a/matrix/cluster/ray_cluster.py
+++ b/matrix/cluster/ray_cluster.py
@@ -242,7 +242,14 @@ class RayCluster:
                 folder=str(self._log_dir),
                 cluster=executor,
             )
-            default_params = {"cpus_per_task": 20, "timeout_min": 10080}
+            default_params = {"timeout_min": 10080, "cpus_per_task": 20}
+            if executor == "slurm":
+                # clusterscope assigns the proportionate amount of resources based on gpus/cpus being requested.
+                resources = clusterscope.job_gen_task_slurm(
+                    partition=requirements["partition"],
+                    cpus_per_task=default_params["cpus_per_task"],
+                )
+                default_params["mem_gb"] = resources["mem_gb"]
             if add_workers == 0:
                 head_params = requirements
             else:
@@ -308,10 +315,18 @@ class RayCluster:
             )
             default_params = {
                 "ntasks_per_node": 1,
-                "cpus_per_task": 96,
                 "timeout_min": 10080,
                 "gpus_per_node": 8,
             }
+            if executor == "slurm":
+                # clusterscope assigns the proportionate amount of resources based on gpus/cpus being requested.
+                resources = clusterscope.job_gen_task_slurm(
+                    partition=requirements["partition"],
+                    gpus_per_task=default_params["gpus_per_node"],
+                    ntasks_per_node=default_params["ntasks_per_node"],
+                )
+                default_params["cpus_per_task"] = resources["cpus_per_task"]
+                default_params["mem_gb"] = resources["mem_gb"]
             requirements.update(
                 {
                     key: value

--- a/matrix/cluster/ray_cluster.py
+++ b/matrix/cluster/ray_cluster.py
@@ -18,6 +18,8 @@ import time
 import typing as tp
 from pathlib import Path
 
+import clusterscope
+
 from matrix.common import JOB_MANAGER_STORE
 from matrix.common.cluster_info import ClusterInfo
 from matrix.utils.basics import convert_to_json_compatible

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "requests~=2.32",
   "httpx~=0.28",
   "openai~=1.90",
+  "clusterscope",
 ]
 # zip_safe = false
 classifiers=[


### PR DESCRIPTION
## Why ?

[clusterscope](https://github.com/facebookresearch/clusterscope/) has an API to calculate proportionate resource usage in the machine (CPUs / Mem) given the number of GPUs or CPUs.

notice how the original code has the following args:
```
"ntasks_per_node": 1,
"cpus_per_task": 96,
"gpus_per_node": 8,
```

H100 nodes have 192 cpus, the code above only uses 96 cpus per node (96 cpus_per_task * 1 ntasks_per_node), leaving the other 96 cpus idle.

what clusterscope provides is an API that will allocate the appropriate number of CPUs and Memory given the number of GPUs requested. it goes something like:

1. request 8 GPUs 
2. clusterscope gets total cpus and memory for the nodes 
3. clusterscope allocates cpus/memory based on the proportion of GPUs being requested

H100 nodes have 8 GPUs total, so this means clusterscope will allocate all memory and all cpus

## Test plan

github ci
