### PR TITLE
fix prompt_logprobs for llm via http request

### DIFF
--- a/matrix/client/query_llm.py
+++ b/matrix/client/query_llm.py
@@ -405,13 +405,8 @@ async def make_request(
                             ]
                             result["response"]["logprobs"] = lp
                         if prompt_logprobs is not None and response.choices[0].prompt_logprobs is not None:  # type: ignore[attr-defined]
-                            lp = [
-                                [
-                                    _convert_token_log_probs(elem)
-                                    for elem in response.choices[i].prompt_logprobs  # type: ignore[attr-defined]
-                                ]
-                                for i in range(n)
-                            ]
+                            # note: only grpc need conversion
+                            lp = [response.choices[i].prompt_logprobs for i in range(n)]  # type: ignore[attr-defined]
                             result["response"]["prompt_logprobs"] = lp
                     else:
                         raise Exception(
@@ -592,13 +587,12 @@ async def make_request(
                                     for token, lp_token, top_lp in zip(
                                         response.choices[i].logprobs.tokens,  # type: ignore[union-attr]
                                         response.choices[i].logprobs.token_logprobs,  # type: ignore[union-attr]
-                                        response.choices[i].logprobs.top_logprobs  # type: ignore[union-attr]
-                                        or [
+                                        [
                                             None
                                             for _ in range(
                                                 len(response.choices[i].logprobs.tokens)  # type: ignore[union-attr]
                                             )
-                                        ],
+                                        ],  # top_logprobs not supported,
                                     )
                                 ]
                                 for i in range(n)

--- a/matrix/cluster/ray_cluster.py
+++ b/matrix/cluster/ray_cluster.py
@@ -219,6 +219,15 @@ class RayCluster:
         requirements = slurm or local or {}
         requirements = _normalize_slurm_keys(requirements)
         executor = "slurm" if slurm else "local"
+        if executor == "slurm" and "partition" not in requirements:
+            output = subprocess.check_output(["sinfo", "-h", "-o", "%P"])
+            default_partition = [
+                line.split("*")[0]
+                for line in output.decode().splitlines()
+                if "*" in line
+            ]
+            assert len(default_partition) == 1, f"Add partition to --slurm"
+            requirements["partition"] = default_partition[0]
 
         if self._cluster_json.exists():
             cluster = self.cluster_info()


### PR DESCRIPTION
## Why ?

For issue #43, vllm 0.8.3 will crash. While vllm 0.10.2 works. Instructions to install 0.10.2 is based on https://github.com/facebookresearch/matrix/pull/68 (change to vllm_0102)

## How ?
* http mode has parsing issues that fixed.
* also fix the missing partition issue

## Test plan

matrix deploy_applications --action add --applications  "[{'model_name': '/datasets/pretrained-llms/Llama-3.1-8B-Instruct', 'use_grpc': 'true', 'min_replica': 1, 'model_size': '8B', 'name': '8Bgrpc'}, {'model_name': '/datasets/pretrained-llms/Llama-3.1-8B-Instruct', 'use_grpc': 'false', 'min_replica': 1, 'model_size': '8B', 'name': '8B'}]"

run the following for both 8B and 8Bgrpc.

from matrix import Cli
from matrix.client import query_llm

metadata = Cli(cluster_id=None).get_app_metadata(app_name="8B")

for _ in range(10):
    response = asyncio.run(
        query_llm.make_request(
            url=metadata["endpoints"]["head"],
            model=metadata["model_name"],
            app_name=metadata["name"],
            data={
                "prompt": "You are playing a Textual Pictionary Game. Your task is to deduce a word or phrase from a given description. Submit your answer along with your reasoning. You may ask questions to clarify the description, but do not request hints or confirmation. Answering correctly earlier earns higher rewards, but incorrect early answers may incur penalties."
            },
            temperature=0.9,
            logprobs=True,
            prompt_logprobs=10,
        )
    )
print(response)
