### PR TITLE
override the slurm default params

### DIFF
--- a/matrix/cluster/ray_cluster.py
+++ b/matrix/cluster/ray_cluster.py
@@ -330,7 +330,7 @@ class RayCluster:
                 "gpus_per_node": 8,
             }
             default_params.update(
-                {k: requirements[k] for k in default_params if k in requirements}
+                {k: requirements[k] for k in default_params if k in requirements}  # type: ignore[misc]
             )
             if executor == "slurm":
                 # clusterscope assigns the proportionate amount of resources based on gpus/cpus being requested.


### PR DESCRIPTION
## Why ?

default_params can't be override even if they are specified in the slurm argument

## How ?

override it.

## Test plan

matrix start_cluster --add_workers 1 --slurm '{"account": data, "qos": h100_foundations_shared, "gpus_per_node": 7}'