### PR TITLE
Add default HTTP timeouts to helper wrappers

### DIFF
--- a/matrix/utils/http.py
+++ b/matrix/utils/http.py
@@ -7,7 +7,6 @@
 import aiohttp
 import requests
 
-
 DEFAULT_HTTP_TIMEOUT_SECONDS = 30
 
 

--- a/matrix/utils/http.py
+++ b/matrix/utils/http.py
@@ -8,10 +8,16 @@ import aiohttp
 import requests
 
 
-async def post_url(session, url, data=None):
-    """Send a POST request to a given URL with optional data, returning status and content."""
+DEFAULT_HTTP_TIMEOUT_SECONDS = 30
+
+
+async def post_url(session, url, data=None, timeout=DEFAULT_HTTP_TIMEOUT_SECONDS):
+    """Send a POST request and return ``(status_code, text_content)``.
+
+    A default timeout is applied to avoid indefinitely hanging control-plane calls.
+    """
     try:
-        async with session.post(url, json=data) as response:
+        async with session.post(url, json=data, timeout=timeout) as response:
             status = response.status  # Get the HTTP status code
             content = await response.text()  # Get the response body as text
             return status, content
@@ -19,11 +25,14 @@ async def post_url(session, url, data=None):
         return None, repr(e)  # Return None for status and error message as content
 
 
-async def fetch_url(url, headers=None):
-    """Asynchronously fetch data from a single URL, returning status code and content."""
+async def fetch_url(url, headers=None, timeout=DEFAULT_HTTP_TIMEOUT_SECONDS):
+    """Asynchronously fetch a URL and return ``(status_code, text_content)``.
+
+    A default timeout is applied to avoid indefinitely hanging health checks.
+    """
     try:
         async with aiohttp.ClientSession() as session:
-            async with session.get(url, headers=headers) as response:
+            async with session.get(url, headers=headers, timeout=timeout) as response:
                 status = response.status  # Get the status code
                 content = await response.text()  # Get response body as text
                 return status, content
@@ -31,10 +40,13 @@ async def fetch_url(url, headers=None):
         return None, f"Unexpected error: {str(e)}"
 
 
-def fetch_url_sync(url, headers=None):
-    """Synchronously fetch data from a single URL, returning status code and content."""
+def fetch_url_sync(url, headers=None, timeout=DEFAULT_HTTP_TIMEOUT_SECONDS):
+    """Synchronously fetch a URL and return ``(status_code, text_content)``.
+
+    A default timeout is applied to avoid indefinitely hanging health checks.
+    """
     try:
-        response = requests.get(url, headers=headers)
+        response = requests.get(url, headers=headers, timeout=timeout)
         status = response.status_code  # Get the status code
         content = response.text  # Get response body as text
         return status, content

--- a/tests/unit/utils/test_http.py
+++ b/tests/unit/utils/test_http.py
@@ -120,3 +120,69 @@ def test_fetch_url_sync(unused_tcp_port):
         status, content = fetch_url_sync("http://127.0.0.1:1")
         assert status is None
         assert "boom" in content
+
+
+@pytest.mark.asyncio
+async def test_post_url_forwards_timeout():
+    async with aiohttp.ClientSession() as session:
+        with patch.object(session, "post", side_effect=Exception("boom")) as mock_post:
+            await post_url(session, "http://example.com", timeout=1.25)
+
+    mock_post.assert_called_once_with(
+        "http://example.com", json=None, timeout=1.25
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_url_forwards_timeout():
+    class _DummyResponse:
+        status = 200
+
+        async def text(self):
+            return "ok"
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _DummySession:
+        def __init__(self):
+            self.calls = []
+
+        def get(self, url, headers=None, timeout=None):
+            self.calls.append((url, headers, timeout))
+            return _DummyResponse()
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    dummy_session = _DummySession()
+    with patch("matrix.utils.http.aiohttp.ClientSession", return_value=dummy_session):
+        status, content = await fetch_url(
+            "http://example.com", headers={"x": "1"}, timeout=2.5
+        )
+
+    assert status == 200
+    assert content == "ok"
+    assert dummy_session.calls == [
+        ("http://example.com", {"x": "1"}, 2.5)
+    ]
+
+
+def test_fetch_url_sync_forwards_timeout():
+    with patch("matrix.utils.http.requests.get") as mock_get:
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.text = "ok"
+
+        status, content = fetch_url_sync("http://example.com", timeout=3.0)
+
+    assert status == 200
+    assert content == "ok"
+    mock_get.assert_called_once_with(
+        "http://example.com", headers=None, timeout=3.0
+    )


### PR DESCRIPTION
## What changed
- Added a default timeout (`DEFAULT_HTTP_TIMEOUT_SECONDS = 30`) to all HTTP helper wrappers in `matrix/utils/http.py`:
  - `post_url(..., timeout=...)`
  - `fetch_url(..., timeout=...)`
  - `fetch_url_sync(..., timeout=...)`
- Passed the timeout through to underlying network calls (`aiohttp` and `requests`).
- Added unit tests in `tests/unit/utils/test_http.py` to verify timeout forwarding for async POST/GET and sync GET helpers.

## Why
- These helpers are used for control-plane calls (health checks, container endpoints, orchestration paths).
- Without explicit timeouts, transient network stalls can block indefinitely, causing stuck jobs and delayed recovery.
- A bounded default keeps behavior safe by default while preserving flexibility (callers can still override timeout explicitly).

## Insight / Why this matters
- **Root cause:** helper wrappers delegated directly to HTTP clients without setting timeouts, inheriting potentially unbounded wait behavior.
- **Why easy to miss:** localhost and healthy-network tests usually return quickly, so hangs only appear under partial outages or degraded endpoints.
- **Impact:** failures surface faster and retries/recovery loops can progress instead of hanging on a single blocked request.
- **Tradeoff:** a default timeout may surface timeout errors where callers previously waited forever; this is intentional for reliability and can be tuned per call.

## Practical gain / Why this matters
- Improves reliability for users running Matrix in real distributed environments with intermittent endpoint issues.
- Reduces “stuck” orchestration symptoms by making helper-level network behavior deterministic.
- Provides regression protection via explicit timeout-forwarding tests.

## Testing
- ✅ `pytest -q tests/unit/utils/test_http.py`
  - Result: `8 passed`
- ✅ `scripts/clone_and_test.sh facebookresearch/matrix`
  - Result: `78 passed`

## Risk analysis
- Scope is narrow (HTTP helper wrappers + tests only).
- No behavior change for successful fast requests.
- Rollback-safe: removing default timeout behavior is straightforward if maintainers prefer a different default.